### PR TITLE
Add Stale bot to autoclose dead issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/stale.yml
+++ b/.github/ISSUE_TEMPLATE/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+# Setting this to 100 years, because we do not want to automatically mark issues as stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Label to use when marking an issue as stale
+staleLabel: closing-soon-if-no-response
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because of inactivity.
+  Please open a new issue if are still encountering problems.
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
This bot marks issues that have not had a response in 30 days as stale; if there's no further activity after a further 7 days then the issue is automatically closed.