### PR TITLE
Null arn api gateway

### DIFF
--- a/source/backend/discovery/src/lib/additionalResources/firstOrderHandlers.js
+++ b/source/backend/discovery/src/lib/additionalResources/firstOrderHandlers.js
@@ -95,7 +95,7 @@ module.exports = {
                         resourceName: arn,
                         relationships: [
                             createContainedInRelationship(AWS_API_GATEWAY_REST_API, {resourceId}),
-                            ...authorizer.providerARNs.map(resourceId => createAssociatedRelationship(AWS_COGNITO_USER_POOL, {resourceId}))
+                            ...(authorizer.providerARNs ?? []).map(resourceId => createAssociatedRelationship(AWS_COGNITO_USER_POOL, {resourceId}))
                         ]
                     }, {RestApiId, ...authorizer});
                 }));

--- a/source/backend/discovery/test/additionalRelationships.js
+++ b/source/backend/discovery/test/additionalRelationships.js
@@ -723,7 +723,7 @@ describe('additionalRelationships', () => {
                 }]);
             });
 
-            it.only('should handle errors when encrypted environment variables are present', async () => {
+            it('should handle errors when encrypted environment variables are present', async () => {
                 const schema = require('./fixtures/relationships/lambda/encryptedEnvVar.json');
                 const {lambda} = generate(schema);
 

--- a/source/backend/discovery/test/createAdditionalResources.js
+++ b/source/backend/discovery/test/createAdditionalResources.js
@@ -923,7 +923,7 @@ describe('importAdditionalResources', () => {
 
         describe(AWS_API_GATEWAY_AUTHORIZER, () => {
 
-            it('should discover API Gateway authorizers ith no providers', async () => {
+            it('should discover API Gateway authorizers with no providers', async () => {
                 const schema = require('./fixtures/additionalResources/apigateway/authorizerNoProvider.json');
                 const {restApi, apiGwAuthorizer} = generate(schema);
 

--- a/source/backend/discovery/test/createAdditionalResources.js
+++ b/source/backend/discovery/test/createAdditionalResources.js
@@ -923,7 +923,56 @@ describe('importAdditionalResources', () => {
 
         describe(AWS_API_GATEWAY_AUTHORIZER, () => {
 
-            it('should discover API Gateway authorizers', async () => {
+            it('should discover API Gateway authorizers ith no providers', async () => {
+                const schema = require('./fixtures/additionalResources/apigateway/authorizerNoProvider.json');
+                const {restApi, apiGwAuthorizer} = generate(schema);
+
+                const mockApiGatewayClient = {
+                    createApiGatewayClient(accountId, credentials, region) {
+                        return {
+                            getResources: async restApi => [],
+                            async getAuthorizers(restApi) {
+                                if(credentials.accessKeyId === ACCESS_KEY_X && region === EU_WEST_2) {
+                                    return [apiGwAuthorizer];
+                                }
+                            }
+                        }
+                    }
+                }
+
+                const arn = `arn:aws:apigateway:${EU_WEST_2}::/restapis/${restApi.configuration.id}/authorizers/${apiGwAuthorizer.id}`;
+
+                const actual = await createAdditionalResources({...mockAwsClient, ...mockApiGatewayClient}, [restApi]);
+
+                const actualApiGwResource = actual.find(x => x.arn === arn);
+
+                assert.deepEqual(actualApiGwResource, {
+                    id: arn,
+                    accountId: ACCOUNT_X,
+                    arn: arn,
+                    availabilityZone: NOT_APPLICABLE,
+                    awsRegion: EU_WEST_2,
+                    configuration: {
+                        RestApiId: restApi.configuration.id,
+                        id: apiGwAuthorizer.id
+                    },
+                    configurationItemStatus: RESOURCE_DISCOVERED,
+                    resourceId: arn,
+                    resourceName: arn,
+                    resourceType: AWS_API_GATEWAY_AUTHORIZER,
+                    tags: [],
+                    relationships: [
+                        {
+                            relationshipName: IS_CONTAINED_IN,
+                            resourceId: restApi.configuration.id,
+                            resourceType: AWS_API_GATEWAY_REST_API
+                        }
+                    ]
+                });
+
+            });
+
+            it('should discover API Gateway Cognito authorizers', async () => {
                 const schema = require('./fixtures/additionalResources/apigateway/authorizer.json');
                 const {restApi, cognito, apiGwAuthorizer} = generate(schema);
 

--- a/source/backend/discovery/test/fixtures/additionalResources/apigateway/authorizerNoProvider.json
+++ b/source/backend/discovery/test/fixtures/additionalResources/apigateway/authorizerNoProvider.json
@@ -1,0 +1,21 @@
+{
+  "$constants": {
+    "accountId": "xxxxxxxxxxxx",
+    "region": "eu-west-2"
+  },
+  "restApi": {
+    "id": "restApiArn",
+    "accountId": "${$constants.accountId}",
+    "awsRegion": "${$constants.region}",
+    "availabilityZone": "Not Applicable",
+    "resourceType": "AWS::ApiGateway::RestApi",
+    "resourceId": "restApiId",
+    "relationships": [],
+    "configuration": {
+      "id": "${restApi.resourceId}"
+    }
+  },
+  "apiGwAuthorizer": {
+    "id": "apiGwAuthorizerId"
+  }
+}


### PR DESCRIPTION
The code to create relationships for API Gateway authorizers assumes that the providerARNs field is always present. This is not the case so we now provide a fallback value of [] before mapping over it.
