### PR TITLE
Split create additional relationships

### DIFF
--- a/source/backend/discovery/src/lib/additionalRelationships/createBatchedHandlers.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/createBatchedHandlers.js
@@ -1,0 +1,124 @@
+const R = require("ramda");
+const createEnvironmentVariableRelationships = require('./createEnvironmentVariableRelationships');
+const logger = require("../logger");
+const {
+    safeForEach,
+    createAssociatedRelationship,
+    createArn,
+    createAttachedRelationship} = require("../utils");
+const {
+    VPC,
+    EC2,
+    TRANSIT_GATEWAY_ATTACHMENT,
+    AWS_EC2_TRANSIT_GATEWAY,
+    AWS_EC2_VPC,
+    AWS_EC2_SUBNET,
+    SUBNET
+} = require("../constants");
+
+function createBatchedHandlers(lookUpMaps, awsClient, resourceMap) {
+    const {
+        envVarResourceIdentifierToIdMap,
+        dbUrlToIdMap
+    } = lookUpMaps;
+
+    return {
+        eventSources: async (credentials, accountId, region) => {
+            const lambdaClient = awsClient.createLambdaClient(credentials, region);
+            const eventSourceMappings = await lambdaClient.listEventSourceMappings();
+
+            const {errors} = safeForEach(({EventSourceArn, FunctionArn}) => {
+                if(resourceMap.has(EventSourceArn) && resourceMap.has(FunctionArn)) {
+                    const {resourceType} = resourceMap.get(EventSourceArn);
+                    const lambda = resourceMap.get(FunctionArn);
+
+                    lambda.relationships.push(createAssociatedRelationship(resourceType, {
+                        arn: EventSourceArn
+                    }));
+                }
+            }, eventSourceMappings);
+
+            logger.error(`There were ${errors.length} errors when adding lambda event source relationships in region ${region} of account ${accountId}.`);
+            logger.debug('Errors: ', {errors});
+        },
+        functions: async (credentials, accountId, region) => {
+            const lambdaClient = awsClient.createLambdaClient(credentials, region);
+
+            const lambdas = await lambdaClient.getAllFunctions();
+
+            const {errors} = safeForEach(({FunctionArn, Environment = {}}) => {
+                const lambda = resourceMap.get(FunctionArn);
+                // a lambda may have been created between the time we got the data from config
+                // and made our api request
+                if(lambda != null && !R.isEmpty(Environment)) {
+                    // The lambda API returns an error object if there are encrypted environment variables
+                    // that the discovery process does not have permissions to decrypt
+                    if(R.isNil(Environment.Error)) {
+                        //TODO: add env var name as a property of the edge
+                        lambda.relationships.push(...createEnvironmentVariableRelationships(
+                            {resourceMap, envVarResourceIdentifierToIdMap, dbUrlToIdMap},
+                            {accountId, awsRegion: region},
+                            Environment.Variables));
+                    }
+                }
+            }, lambdas);
+
+            logger.error(`There were ${errors.length} errors when adding lambda environment variable relationships in region ${region} of account ${accountId}.`);
+            logger.debug('Errors: ', {errors});
+        },
+        snsSubscriptions: async (credentials, accountId, region) => {
+            const snsClient = awsClient.createSnsClient(credentials, region);
+
+            const subscriptions = await snsClient.getAllSubscriptions();
+
+            const {errors} = safeForEach(({Endpoint, TopicArn}) => {
+                // an SNS topic may have been created between the time we got the data from config
+                // and made our api request or the endpoint may have been created in a region that
+                // has not been imported
+                if(resourceMap.has(TopicArn) && resourceMap.has(Endpoint)) {
+                    const snsTopic = resourceMap.get(TopicArn);
+                    const {resourceType} = resourceMap.get(Endpoint);
+                    snsTopic.relationships.push(createAssociatedRelationship(resourceType, {arn: Endpoint}));
+                }
+            }, subscriptions);
+
+            logger.error(`There were ${errors.length} errors when adding SNS subscriber relationships in region ${region} of account ${accountId}.`);
+            logger.debug('Errors: ', {errors});
+        },
+        transitGatewayVpcAttachments: async (credentials, accountId, region) => {
+            // Whilst AWS Config supports the AWS::EC2::TransitGatewayAttachment resource type,
+            // it is missing information on the account that VPCs referred to by the attachment
+            // are deployed in. Therefore we need to supplement this with info from the EC2 API.
+            const ec2Client = awsClient.createEc2Client(credentials, region);
+
+            const tgwAttachments = await ec2Client.getAllTransitGatewayAttachments([
+                {Name: 'resource-type', Values: [VPC.toLowerCase()]}
+            ]);
+
+            const {errors} = safeForEach(tgwAttachment => {
+                const {
+                    TransitGatewayAttachmentId, ResourceOwnerId, TransitGatewayOwnerId, TransitGatewayId
+                } = tgwAttachment;
+                const tgwAttachmentArn = createArn({
+                    service: EC2, region, accountId, resource: `${TRANSIT_GATEWAY_ATTACHMENT}/${TransitGatewayAttachmentId}`}
+                );
+
+                if(resourceMap.has(tgwAttachmentArn)) {
+                    const tgwAttachmentFromConfig = resourceMap.get(tgwAttachmentArn);
+                    const {relationships, configuration: {SubnetIds, VpcId}} =  tgwAttachmentFromConfig;
+
+                    relationships.push(
+                        createAttachedRelationship(AWS_EC2_TRANSIT_GATEWAY, {accountId: TransitGatewayOwnerId, awsRegion: region, resourceId: TransitGatewayId}),
+                        createAssociatedRelationship(AWS_EC2_VPC, {relNameSuffix: VPC, accountId: ResourceOwnerId, awsRegion: region, resourceId: VpcId}),
+                        ...SubnetIds.map(subnetId => createAssociatedRelationship(AWS_EC2_SUBNET, {relNameSuffix: SUBNET, accountId: ResourceOwnerId, awsRegion: region, resourceId: subnetId}))
+                    );
+                }
+            }, tgwAttachments);
+
+            logger.error(`There were ${errors.length} errors when adding transit gateway relationships in region ${region} of account ${accountId}.`);
+            logger.debug('Errors: ', {errors});
+        }
+    }
+}
+
+module.exports = createBatchedHandlers

--- a/source/backend/discovery/src/lib/additionalRelationships/createEnvironmentVariableRelationships.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/createEnvironmentVariableRelationships.js
@@ -1,0 +1,38 @@
+const {createAssociatedRelationship, createResourceIdKey, createResourceNameKey} = require("../utils");
+const {AWS_S3_ACCOUNT_PUBLIC_ACCESS_BLOCK} = require("../constants");
+
+function createEnvironmentVariableRelationships(
+    {resourceMap, envVarResourceIdentifierToIdMap, dbUrlToIdMap},
+    {accountId, awsRegion},
+    variables
+) {
+    //TODO: add env var name as a property of the edge
+    return Object.values(variables).reduce((acc, val) => {
+        if (resourceMap.has(val)) {
+            const {resourceType, arn} = resourceMap.get(val);
+            acc.push(createAssociatedRelationship(resourceType, {arn}));
+        } else {
+            // this branch assumes all resources are in the same region
+            const resourceIdKey = createResourceIdKey({resourceId: val, accountId, awsRegion});
+            const resourceNameKey = createResourceNameKey({resourceName: val, accountId, awsRegion});
+
+            const id = envVarResourceIdentifierToIdMap.get(resourceIdKey)
+                ?? envVarResourceIdentifierToIdMap.get(resourceNameKey)
+                ?? dbUrlToIdMap.get(val);
+
+            if(resourceMap.has(id)) {
+                const {resourceType, resourceId} = resourceMap.get(id);
+
+                // The resourceId of the AWS::S3::AccountPublicAccessBlock resource type is the accountId where it resides.
+                // We need to filter out environment variables that have AWS account IDs because otherwise we will create
+                // an erroneous relationship between the resource and the AWS::S3::AccountPublicAccessBlock
+                if(resourceId !== accountId && resourceType !== AWS_S3_ACCOUNT_PUBLIC_ACCESS_BLOCK) {
+                    acc.push(createAssociatedRelationship(resourceType, {arn: id}));
+                }
+            }
+        }
+        return acc;
+    }, []);
+}
+
+module.exports = createEnvironmentVariableRelationships;

--- a/source/backend/discovery/src/lib/additionalRelationships/createLookUpMaps.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/createLookUpMaps.js
@@ -1,0 +1,96 @@
+const R = require("ramda");
+const {
+    AWS_AUTOSCALING_AUTOSCALING_GROUP,
+    AWS_ELASTICSEARCH_DOMAIN,
+    AWS_OPENSEARCH_DOMAIN,
+    AWS_ELASTIC_LOAD_BALANCING_LOADBALANCER,
+    AWS_ELASTIC_LOAD_BALANCING_V2_LOADBALANCER,
+    AWS_RDS_DB_CLUSTER,
+    AWS_RDS_DB_INSTANCE,
+    AWS_REDSHIFT_CLUSTER,
+    AWS_S3_BUCKET
+} = require("../constants");
+const {createResourceNameKey, createResourceIdKey} = require('../utils');
+
+function createLookUpMaps(resources) {
+    const targetGroupToAsgMap = new Map();
+    const resourceIdentifierToIdMap = new Map();
+    // we can't reuse resourceIdentifierToIdMap because we don't know the resource type for env vars
+    const envVarResourceIdentifierToIdMap = new Map();
+    const dbUrlToIdMap = new Map();
+    const elbDnsToResourceIdMap = new Map();
+    const asgResourceNameToResourceIdMap = new Map();
+    const s3ResourceIdToRegionMap = new Map();
+
+    for(let resource of resources) {
+        const {id, resourceType, resourceId, resourceName, accountId, awsRegion, arn, configuration} = resource;
+
+        if(resourceName != null) {
+            envVarResourceIdentifierToIdMap.set(createResourceNameKey({resourceName, accountId, awsRegion}), id);
+            resourceIdentifierToIdMap.set(
+                createResourceNameKey({resourceName, resourceType, accountId, awsRegion}),
+                id);
+        }
+
+        resourceIdentifierToIdMap.set(
+            createResourceIdKey({resourceId, resourceType, accountId, awsRegion}),
+            id);
+        envVarResourceIdentifierToIdMap.set(createResourceIdKey({resourceId, accountId, awsRegion}), id);
+
+        switch (resourceType) {
+            case AWS_AUTOSCALING_AUTOSCALING_GROUP:
+                configuration.targetGroupARNs.forEach(tg =>
+                    targetGroupToAsgMap.set(tg, {
+                        arn,
+                        instances: new Set(configuration.instances.map(R.prop('instanceId')))
+                    }));
+                asgResourceNameToResourceIdMap.set(
+                    createResourceNameKey(
+                        {resourceName, accountId, awsRegion}),
+                    resourceId);
+                break;
+            case AWS_ELASTICSEARCH_DOMAIN:
+                if(configuration.endpoint != null) dbUrlToIdMap.set(configuration.endpoint, id)
+                Object.values(configuration.endpoints ?? []).forEach(endpoint => dbUrlToIdMap.set(endpoint, id));
+                break;
+            case AWS_OPENSEARCH_DOMAIN:
+                if(configuration.Endpoint != null) dbUrlToIdMap.set(configuration.Endpoint, id)
+                Object.values(configuration.Endpoints ?? []).forEach(endpoint => dbUrlToIdMap.set(endpoint, id));
+                break;
+            case AWS_ELASTIC_LOAD_BALANCING_LOADBALANCER:
+                elbDnsToResourceIdMap.set(configuration.dnsname, {resourceId, resourceType, awsRegion});
+                break;
+            case AWS_ELASTIC_LOAD_BALANCING_V2_LOADBALANCER:
+                elbDnsToResourceIdMap.set(configuration.dNSName, {resourceId, resourceType, awsRegion});
+                break;
+            // databases in the 'creating' phase don't have an endpoint field
+            case AWS_RDS_DB_CLUSTER:
+                if(configuration.endpoint != null) dbUrlToIdMap.set(configuration.endpoint.value, id);
+                if(configuration.readerEndpoint != null) dbUrlToIdMap.set(configuration.readerEndpoint, id);
+                break;
+            case AWS_RDS_DB_INSTANCE:
+                if(configuration.endpoint != null) dbUrlToIdMap.set(configuration.endpoint.address, id);
+                break;
+            case AWS_REDSHIFT_CLUSTER:
+                if(configuration.endpoint != null) dbUrlToIdMap.set(configuration.endpoint.address, id);
+                break;
+            case AWS_S3_BUCKET:
+                s3ResourceIdToRegionMap.set(resourceId, awsRegion);
+                break
+            default:
+                break;
+        }
+    }
+
+    return {
+        dbUrlToIdMap,
+        resourceIdentifierToIdMap,
+        targetGroupToAsgMap,
+        elbDnsToResourceIdMap,
+        asgResourceNameToResourceIdMap,
+        s3ResourceIdToRegionMap,
+        envVarResourceIdentifierToIdMap
+    }
+}
+
+module.exports = createLookUpMaps;

--- a/source/backend/discovery/src/lib/additionalRelationships/index.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/index.js
@@ -1,0 +1,114 @@
+const R = require("ramda");
+const {PromisePool} = require("@supercharge/promise-pool");
+const createBatchedHandlers = require('./createBatchedHandlers');
+const createIndividualHandlers = require('./createIndividualHandlers');
+const createLookUpMaps = require('./createLookUpMaps');
+const logger = require("../logger");
+const {
+    AWS_EC2_INSTANCE,
+    AWS_EC2_NETWORK_INTERFACE,
+    AWS_EC2_SUBNET,
+    AWS_EC2_VOLUME,
+    AWS_IAM_ROLE,
+    AWS_TAGS_TAG,
+    AWS_CONFIG_RESOURCE_COMPLIANCE,
+    AWS_EC2_VPC,
+    VPC,
+    CONTAINS
+} = require("../constants");
+
+/**
+ * Config appends the resource type to relationship names for these types but does not do so
+ * consistently
+ **/
+const resourceTypesToNormalize = new Set([
+    AWS_EC2_INSTANCE,
+    AWS_EC2_NETWORK_INTERFACE,
+    AWS_EC2_SUBNET,
+    AWS_EC2_VOLUME,
+    AWS_IAM_ROLE
+])
+
+function normaliseRelationshipNames(resource) {
+    if (resource.resourceType !== AWS_TAGS_TAG && resource.resourceType !== AWS_CONFIG_RESOURCE_COMPLIANCE) {
+        const {relationships} = resource;
+        relationships.forEach(rel => {
+            const {resourceType, relationshipName} = rel;
+            if(resourceTypesToNormalize.has(resourceType)) {
+                const [,, relSuffix] = resourceType.split('::');
+                // VPC is in camelcase
+                if(resourceType === AWS_EC2_VPC && !relationshipName.includes(VPC)) {
+                    rel.relationshipName = relationshipName + VPC;
+                } else if(!relationshipName.includes(relSuffix)){
+                    rel.relationshipName = relationshipName + relSuffix;
+                }
+            }
+        });
+    }
+    return resource;
+}
+
+function addVpcInfo(resource) {
+    if (resource.resourceType !== AWS_TAGS_TAG && resource.resourceType !== AWS_CONFIG_RESOURCE_COMPLIANCE) {
+        const {relationships} = resource;
+
+        const [vpcId] = relationships
+            .filter(x => x.resourceType === AWS_EC2_VPC)
+            .map(x => x.resourceId);
+
+        if (vpcId != null) resource.vpcId = vpcId;
+
+        const subnetIds = relationships
+            .filter(x => x.resourceType === AWS_EC2_SUBNET && !x.relationshipName.includes(CONTAINS))
+            .map(x => x.resourceId)
+            .sort();
+
+        if (subnetIds.length === 1) {
+            resource.subnetId = R.head(subnetIds);
+        }
+    }
+    return resource;
+}
+
+module.exports = {
+    // for performance reasons, each handler mutates the items in `resources`
+    createAdditionalRelationships: R.curry(async (accountsMap, awsClient, resources) =>  {
+        const resourceMap = new Map(resources.map(resource => ([resource.id, resource])));
+
+        const lookUpMaps = {
+            accountsMap,
+            ...createLookUpMaps(resources)
+        };
+
+        const credentialsTuples = Array.from(accountsMap.entries());
+
+        const batchedHandlers = createBatchedHandlers(lookUpMaps, awsClient, resourceMap);
+
+        const batchResults = await Promise.allSettled(Object.values(batchedHandlers).flatMap(handler => {
+            return credentialsTuples
+                .flatMap(([accountId, {regions, credentials}]) =>
+                    regions.map(region => handler(credentials, accountId, region))
+                );
+        }));
+
+        const batchErrors = batchResults.filter(x => x.status === 'rejected').map(({reason}) => ({error: reason.message}));
+        logger.error(`There were ${batchErrors.length} errors when adding batch additional relationships.`);
+        logger.debug('Errors: ', {errors: batchErrors});
+
+        const handlers = createIndividualHandlers(lookUpMaps, awsClient, resources, resourceMap);
+
+        const {errors} = await PromisePool
+            .withConcurrency(30)
+            .for(resources)
+            .process(async resource => {
+                const handler = handlers[resource.resourceType];
+                if(handler != null) return handler(resource);
+            });
+
+        logger.error(`There were ${errors.length} errors when adding additional relationships.`);
+        logger.debug('Errors: ', {errors});
+
+        return Array.from(resourceMap.values())
+            .map(R.compose(addVpcInfo, normaliseRelationshipNames));
+    })
+}

--- a/source/backend/discovery/src/lib/utils.js
+++ b/source/backend/discovery/src/lib/utils.js
@@ -121,6 +121,16 @@ function isDate(date) {
     return date && Object.prototype.toString.call(date) === "[object Date]" && !isNaN(date);
 }
 
+function createResourceNameKey({resourceName, resourceType, accountId, awsRegion}) {
+    const first = resourceType == null ? '' : `${resourceType}_`;
+    return `${first}${resourceName}_${accountId}_${awsRegion}`;
+}
+
+function createResourceIdKey({resourceId, resourceType, accountId, awsRegion}) {
+    const first = resourceType == null ? '' : `${resourceType}_`;
+    return `${first}${resourceId}_${accountId}_${awsRegion}`;
+}
+
 function safeForEach(f, xs) {
     const errors = [];
 
@@ -163,6 +173,8 @@ module.exports = {
     isString,
     isObject,
     objToKeyNameArray,
+    createResourceNameKey,
+    createResourceIdKey,
     safeForEach: R.curry(safeForEach),
     profileAsync: R.curry(profileAsync)
 }

--- a/source/backend/discovery/test/apiClient/index.js
+++ b/source/backend/discovery/test/apiClient/index.js
@@ -1,4 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 const {assert} = require('chai');
+const sinon = require('sinon');
 const createAppSync = require('../../src/lib/apiClient/appSync');
 const {createApiClient} = require('../../src/lib/apiClient');
 const {setGlobalDispatcher, getGlobalDispatcher} = require('undici');
@@ -8,8 +12,11 @@ const GetDbResourcesMapPagination = require('../mocks/agents/GetDbResourcesMapPa
 const GetDbRelationshipsMapPagination = require('../mocks/agents/GetDbRelationshipsMapPagination');
 const GenericError = require('../mocks/agents/GenericError');
 const {
-    CONTAINS
+    CONTAINS,
+    AWS_LAMBDA_FUNCTION,
+    FUNCTION_RESPONSE_SIZE_TOO_LARGE
 } = require("../../src/lib/constants");
+const {generateBaseResource} = require("../generator");
 
 describe('persistence/index.js', () => {
 
@@ -68,8 +75,6 @@ describe('persistence/index.js', () => {
             }]]));
         });
 
-<<<<<<< HEAD:source/backend/discovery/test/apiClinet/index.js
-=======
         it('should handle resource to large errors', async () => {
             const resources = [1,2].map(i => {
                 const properties = generateBaseResource(AWS_LAMBDA_FUNCTION, i);
@@ -100,7 +105,6 @@ describe('persistence/index.js', () => {
             assert.deepEqual(actual, new Map(resources.map(resource => [resource.id, resource])));
         });
 
->>>>>>> 4f520ec5 (split createAdditionalRelationships function into modules):source/backend/discovery/test/apiClient/index.js
     });
 
     describe('getDbRelationshipsMap', () => {

--- a/source/backend/discovery/test/apiClinet/index.js
+++ b/source/backend/discovery/test/apiClinet/index.js
@@ -68,6 +68,39 @@ describe('persistence/index.js', () => {
             }]]));
         });
 
+<<<<<<< HEAD:source/backend/discovery/test/apiClinet/index.js
+=======
+        it('should handle resource to large errors', async () => {
+            const resources = [1,2].map(i => {
+                const properties = generateBaseResource(AWS_LAMBDA_FUNCTION, i);
+                return {id: properties.id, label: 'label', md5Hash: '', properties};
+            })
+
+            const appSync = createAppSync({graphgQlUrl: 'https://www.workload-discovery/graphql'});
+            const mockGetResources = sinon.stub();
+
+            mockGetResources
+                .withArgs({pagination: {start: 0, end: 1000}})
+                .rejects(new Error(FUNCTION_RESPONSE_SIZE_TOO_LARGE))
+                .withArgs({pagination: {start: 0, end: 500}})
+                .rejects(new Error(FUNCTION_RESPONSE_SIZE_TOO_LARGE))
+                .withArgs({pagination: {start: 0, end: 250}})
+                .resolves([resources[0]])
+                .withArgs({pagination: {start: 250, end: 1250}})
+                .rejects(new Error(FUNCTION_RESPONSE_SIZE_TOO_LARGE))
+                .withArgs({pagination: {start: 250, end: 750}})
+                .resolves([resources[1]])
+                .withArgs({pagination: {start: 750, end: 1750}})
+                .resolves([]);
+
+            const apiClient = createApiClient({...appSync, getResources: mockGetResources});
+
+            const actual = await apiClient.getDbResourcesMap();
+
+            assert.deepEqual(actual, new Map(resources.map(resource => [resource.id, resource])));
+        });
+
+>>>>>>> 4f520ec5 (split createAdditionalRelationships function into modules):source/backend/discovery/test/apiClient/index.js
     });
 
     describe('getDbRelationshipsMap', () => {


### PR DESCRIPTION
The `createAdditionalRelationships` function was nearly one thousand lines long. This CR splits it up into modules in a similar way to the `sdkResources` functionality. There have been no changes to the code, it has just been moved to different files and all the unit tests passed. CRUX has tried to be smart and made a mess of the diff for the `createIndividualHandlers.js` file.