### PR TITLE
Reduce logging in addBatchedRelationships

### DIFF
--- a/source/backend/discovery/src/lib/constants.js
+++ b/source/backend/discovery/src/lib/constants.js
@@ -133,6 +133,7 @@ module.exports = {
     AWS_AMAZON_COM: 'aws.amazon.com',
     S3: 's3',
     HOME: 'home',
+    FULFILLED: 'fulfilled',
     FUNCTION_RESPONSE_SIZE_TOO_LARGE: 'Function.ResponseSizeTooLarge',
     WORKLOAD_DISCOVERY_TASKGROUP: 'workload-discovery-taskgroup'
 }


### PR DESCRIPTION
The logging when adding relationships that rely on list* APIs is very verbose (4 log statements per region per account). This CR consolidates the logging of errors into one place and makes it consistent with error logging in other parts of the application.
