### PR TITLE
Make code that adds relationships individually consistent with batch handlers

### DIFF
--- a/source/backend/discovery/src/lib/additionalRelationships/index.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/index.js
@@ -1,7 +1,6 @@
 const R = require("ramda");
-const {PromisePool} = require("@supercharge/promise-pool");
 const addBatchedRelationships = require('./addBatchedRelationships');
-const createIndividualHandlers = require('./createIndividualHandlers');
+const addIndividualRelationships = require('./addIndividualRelationships');
 const createLookUpMaps = require('./createLookUpMaps');
 const logger = require("../logger");
 const {
@@ -82,20 +81,9 @@ module.exports = {
 
         await addBatchedRelationships(lookUpMaps, awsClient);
 
-        const handlers = createIndividualHandlers(lookUpMaps, awsClient, resources, resourceMap);
+        await addIndividualRelationships(lookUpMaps, awsClient, resources)
 
-        const {errors} = await PromisePool
-            .withConcurrency(30)
-            .for(resources)
-            .process(async resource => {
-                const handler = handlers[resource.resourceType];
-                if(handler != null) return handler(resource);
-            });
-
-        logger.error(`There were ${errors.length} errors when adding additional relationships.`);
-        logger.debug('Errors: ', {errors});
-
-        return Array.from(resourceMap.values())
+        return resources
             .map(R.compose(addVpcInfo, normaliseRelationshipNames));
     })
 }

--- a/source/backend/discovery/src/lib/additionalRelationships/index.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/index.js
@@ -71,7 +71,7 @@ function addVpcInfo(resource) {
 
 module.exports = {
     // for performance reasons, each handler mutates the items in `resources`
-    createAdditionalRelationships: R.curry(async (accountsMap, awsClient, resources) =>  {
+    addAdditionalRelationships: R.curry(async (accountsMap, awsClient, resources) =>  {
         const resourceMap = new Map(resources.map(resource => ([resource.id, resource])));
 
         const lookUpMaps = {

--- a/source/backend/discovery/src/lib/index.js
+++ b/source/backend/discovery/src/lib/index.js
@@ -6,7 +6,7 @@ const logger = require('./logger');
 const {initialise} = require('./intialisation');
 const getAllConfigResources = require('./aggregator/getAllConfigResources');
 const {getAllSdkResources} = require('./sdkResources');
-const {createAdditionalRelationships} = require('./additionalRelationships');
+const {addAdditionalRelationships} = require('./additionalRelationships');
 const createResourceAndRelationshipDeltas = require('./createResourceAndRelationshipDeltas');
 const {createSaveObject} = require('./persistence/transformers');
 const {writeResourcesAndRelationships} = require('./persistence');
@@ -14,7 +14,7 @@ const {writeResourcesAndRelationships} = require('./persistence');
 function getAllResources(configServiceClient, awsClient, accountsMap, configAggregator) {
     return getAllConfigResources(configServiceClient, accountsMap, configAggregator)
         .then(getAllSdkResources(accountsMap, awsClient))
-        .then(createAdditionalRelationships(accountsMap, awsClient))
+        .then(addAdditionalRelationships(accountsMap, awsClient))
 }
 
 async function discoverResources(appSync, awsClient, config) {


### PR DESCRIPTION
This PR moves the concurrency control to the `addIndividualRelationships` function rather than having it in the main `addAdditionalRelationships` function, which makes it consistent with the batch handlers.