### PR TITLE
use node 16 version aws credentials gh action

### DIFF
--- a/.github/workflows/pipeline-workflow.yml
+++ b/.github/workflows/pipeline-workflow.yml
@@ -14,7 +14,7 @@ jobs:
       id-token: write
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           role-to-assume: ${{ secrets.DISPATCHER_ROLE_ARN }}
           aws-region: ${{ env.REGION }}


### PR DESCRIPTION
Removes Node 12 warning from pipeline workflow