### PR TITLE
don't write relationships field from config to DBs

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="accountSettings">
+    <option name="activeProfile" value="profile:perspective-svozza" />
     <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:perspective-svozza" />
+      </list>
+    </option>
     <option name="recentlyUsedRegions">
       <list>
         <option value="us-east-1" />
       </list>
     </option>
+  </component>
+  <component name="connectionManager">
+    <option name="activeConnectionId" value="AwsConnectionManagerConnection" />
   </component>
 </project>

--- a/source/backend/discovery/src/lib/apiClient/appSync.js
+++ b/source/backend/discovery/src/lib/apiClient/appSync.js
@@ -154,7 +154,6 @@ const getResources = opts => async ({pagination, resourceTypes, accounts}) => {
         loggedInURL
         loginURL
         private
-        relationships
         resourceCreationTime
         resourceName
         resourceId

--- a/source/backend/discovery/src/lib/persistence/transformers.js
+++ b/source/backend/discovery/src/lib/persistence/transformers.js
@@ -153,14 +153,14 @@ function createTitle({resourceId, resourceName, arn, resourceType, tags}) {
 
 const propertiesToKeep = new Set([
     'accountId', 'arn', 'availabilityZone', 'awsRegion', 'configuration', 'configurationItemCaptureTime',
-    'configurationItemStatus', 'configurationStateId', 'relationships', 'resourceCreationTime', 'resourceId',
+    'configurationItemStatus', 'configurationStateId', 'resourceCreationTime', 'resourceId',
     'resourceName', 'resourceType', 'supplementaryConfiguration', 'tags', 'version', 'vpcId', 'subnetId', 'subnetIds',
     'resourceValue', 'state', 'private', 'dBInstanceStatus', 'statement', 'instanceType']);
 
-const propertiesToJsonStringify = new Set(['configuration', 'supplementaryConfiguration', 'tags', 'relationships', 'state'])
+const propertiesToJsonStringify = new Set(['configuration', 'supplementaryConfiguration', 'tags', 'state'])
 
 /**
- * Neptune cannot store nested properties. Therefore this function extracts the
+ * Neptune cannot store nested properties. Therefore, this function extracts the
  * specified and adds them to the main object. It also converts nested fields
  * into JSON.
  * @param {*} node

--- a/source/backend/discovery/test/createResourceAndRelationshipDeltas.js
+++ b/source/backend/discovery/test/createResourceAndRelationshipDeltas.js
@@ -26,8 +26,6 @@ const {
 } = require('../src/lib/constants');
 const {generate} = require('./generator');
 const createResourceAndRelationshipDeltas = require('../src/lib/createResourceAndRelationshipDeltas');
-const {dbResources} = require("./fixtures/createResourceAndRelationshipDeltas/resources/sdkResources.json");
-const {resources} = require("./fixtures/createResourceAndRelationshipDeltas/resources/deletedResources.json");
 
 describe('createResourceAndRelationshipDeltas',  () => {
 

--- a/source/backend/graphql/schema/perspective-api.graphql
+++ b/source/backend/graphql/schema/perspective-api.graphql
@@ -50,7 +50,6 @@ input ResourcePropertiesInput {
     configurationItemCaptureTime: String
     configurationItemStatus: String
     configurationStateId: String
-    relationships: String
     resourceCreationTime: String
     resourceId: String
     resourceName: String
@@ -420,7 +419,6 @@ type ResourceProperties @aws_cognito_user_pools @aws_iam {
   configurationItemCaptureTime: String
   configurationItemStatus: String
   configurationStateId: String
-  relationships: AWSJSON
   resourceCreationTime: String
   resourceId: String
   resourceName: String

--- a/source/frontend/src/API/GraphQL/queries.js
+++ b/source/frontend/src/API/GraphQL/queries.js
@@ -27,7 +27,6 @@ export const getResources = /* GraphQL */ `
         configurationItemCaptureTime
         configurationItemStatus
         configurationStateId
-        relationships
         resourceCreationTime
         resourceId
         resourceName


### PR DESCRIPTION
Issue #, if available: 

Resolves #368

Description of changes:

As described in the rationale in this issue linked above, there is no need to store the `relationships` field we retrieve from AWS Config. This change is mainly focused on the discovery process (although we also remove the field from the GraphQL schema), which was the only component that interacted with that field in the DB.
