### PR TITLE
Simplify creation of lookup maps for creating relationships

### DIFF
--- a/.idea/aws.xml
+++ b/.idea/aws.xml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="accountSettings">
+    <option name="activeProfile" value="profile:perspective-svozza" />
     <option name="activeRegion" value="us-east-1" />
+    <option name="recentlyUsedProfiles">
+      <list>
+        <option value="profile:perspective-svozza" />
+      </list>
+    </option>
     <option name="recentlyUsedRegions">
       <list>
         <option value="us-east-1" />
       </list>
     </option>
+  </component>
+  <component name="connectionManager">
+    <option name="activeConnectionId" value="AwsConnectionManagerConnection" />
   </component>
 </project>

--- a/source/backend/discovery/src/lib/additionalRelationships/addBatchedRelationships.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/addBatchedRelationships.js
@@ -20,7 +20,7 @@ const {
 function createBatchedHandlers(lookUpMaps, awsClient) {
     const {
         envVarResourceIdentifierToIdMap,
-        dbUrlToIdMap,
+        endpointToIdMap,
         resourceMap
     } = lookUpMaps;
 
@@ -55,7 +55,7 @@ function createBatchedHandlers(lookUpMaps, awsClient) {
                     if(R.isNil(Environment.Error)) {
                         //TODO: add env var name as a property of the edge
                         lambda.relationships.push(...createEnvironmentVariableRelationships(
-                            {resourceMap, envVarResourceIdentifierToIdMap, dbUrlToIdMap},
+                            {resourceMap, envVarResourceIdentifierToIdMap, endpointToIdMap},
                             {accountId, awsRegion: region},
                             Environment.Variables));
                     }

--- a/source/backend/discovery/src/lib/additionalRelationships/createEnvironmentVariableRelationships.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/createEnvironmentVariableRelationships.js
@@ -2,7 +2,7 @@ const {createAssociatedRelationship, createResourceIdKey, createResourceNameKey}
 const {AWS_S3_ACCOUNT_PUBLIC_ACCESS_BLOCK} = require("../constants");
 
 function createEnvironmentVariableRelationships(
-    {resourceMap, envVarResourceIdentifierToIdMap, dbUrlToIdMap},
+    {resourceMap, envVarResourceIdentifierToIdMap, endpointToIdMap},
     {accountId, awsRegion},
     variables
 ) {
@@ -18,7 +18,7 @@ function createEnvironmentVariableRelationships(
 
             const id = envVarResourceIdentifierToIdMap.get(resourceIdKey)
                 ?? envVarResourceIdentifierToIdMap.get(resourceNameKey)
-                ?? dbUrlToIdMap.get(val);
+                ?? endpointToIdMap.get(val);
 
             if(resourceMap.has(id)) {
                 const {resourceType, resourceId} = resourceMap.get(id);

--- a/source/backend/discovery/test/additionalRelationships.js
+++ b/source/backend/discovery/test/additionalRelationships.js
@@ -223,7 +223,7 @@ describe('additionalRelationships', () => {
                         relationshipName: IS_ASSOCIATED_WITH,
                         resourceId: s3.resourceId,
                         resourceType: AWS_S3_BUCKET,
-                        awsRegion: s3.awsRegion
+                        arn: s3.arn
                     }
                 ]);
             });
@@ -266,7 +266,7 @@ describe('additionalRelationships', () => {
 
         describe(AWS_CLOUDFRONT_STREAMING_DISTRIBUTION, () => {
 
-            it('should add regiun for s3 buckets', async () => {
+            it('should add region for s3 buckets', async () => {
                 const schema = require('./fixtures/relationships/cloudfrontStreamingDistribution/s3.json');
                 const {cfStreamingDistro, s3} = generate(schema);
 
@@ -278,7 +278,7 @@ describe('additionalRelationships', () => {
                         relationshipName: IS_ASSOCIATED_WITH,
                         resourceId: s3.resourceId,
                         resourceType: AWS_S3_BUCKET,
-                        awsRegion: s3.awsRegion
+                        arn: s3.arn
                     }
                 ]);
             });

--- a/source/backend/discovery/test/fixtures/relationships/cloudfront/distribution/s3.json
+++ b/source/backend/discovery/test/fixtures/relationships/cloudfront/distribution/s3.json
@@ -7,7 +7,7 @@
   },
   "s3": {
     "accountId": "${$constants.accountId}",
-    "arn": "s3Arn",
+    "arn": "arn:aws:s3:::bucketName",
     "resourceType": "AWS::S3::Bucket",
     "resourceId": "bucketName",
     "resourceName": "bucketName",

--- a/source/backend/discovery/test/fixtures/relationships/cloudfrontStreamingDistribution/s3.json
+++ b/source/backend/discovery/test/fixtures/relationships/cloudfrontStreamingDistribution/s3.json
@@ -7,7 +7,7 @@
   },
   "s3": {
     "accountId": "${$constants.accountId}",
-    "arn": "s3Arn",
+    "arn": "arn:aws:s3:::bucketName",
     "resourceType": "AWS::S3::Bucket",
     "resourceId": "bucketName",
     "resourceName": "bucketName",


### PR DESCRIPTION
Description of changes:

The discovery process uses a series of hash maps so that when creating relationships between  resources we can do look ups for specific resources in O(1) time rather than search the array (an O(n) operation) of resources we get from AWS Config. Over time, the function that creates these maps has become quite complex. 

This PR factors out some common logic when creating these hash maps into separate function, which allows us to reduce the number of cases in the `switch` statement. We also remove one of the maps (`s3ResourceIdToRegionMap`) entirely as we can use the the ARN of the S3 bucket to find it because we know they are globally unique.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
