### PR TITLE
Record and display IAM errors when discovering accounts

### DIFF
--- a/source/backend/discovery/src/lib/apiClient/appSync.js
+++ b/source/backend/discovery/src/lib/apiClient/appSync.js
@@ -92,6 +92,7 @@ const getAccounts = opts => async () => {
       query ${name} {
         getAccounts {
           accountId
+          lastCrawled
           regions {
             name
           }
@@ -278,16 +279,16 @@ const addAccounts = opts => async accounts => {
     return sendQuery(opts, name, {query, variables});
 }
 
-const updateAccount = opts => async (accountId, lastCrawled) => {
+const updateAccount = opts => async (accountId, accountName, isIamRoleDeployed, lastCrawled) => {
     const name = 'updateAccount';
     const query = `
-    mutation ${name}($accountId: String!, $lastCrawled: AWSDateTime) {
-      ${name}(accountId: $accountId, lastCrawled: $lastCrawled) {
+    mutation ${name}($accountId: String!, $name: String, $isIamRoleDeployed: Boolean, $lastCrawled: AWSDateTime) {
+      ${name}(accountId: $accountId, name: $name, isIamRoleDeployed: $isIamRoleDeployed, lastCrawled: $lastCrawled) {
         accountId
         lastCrawled
       }
     }`;
-    const variables = {accountId, lastCrawled};
+    const variables = {accountId, name: accountName, lastCrawled, isIamRoleDeployed};
     return sendQuery(opts, name, {query, variables});
 };
 

--- a/source/backend/discovery/src/lib/config.js
+++ b/source/backend/discovery/src/lib/config.js
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+const {AWS_ORGANIZATIONS} = require("./constants");
 const config = {
     rootAccountId: process.env.AWS_ACCOUNT_ID,
     region: process.env.AWS_REGION,
     cluster: process.env.CLUSTER,
     crossAccountDiscovery: process.env.CROSS_ACCOUNT_DISCOVERY,
+    isUsingOrganizations: process.env.CROSS_ACCOUNT_DISCOVERY === AWS_ORGANIZATIONS,
     configAggregator: process.env.CONFIG_AGGREGATOR,
     graphgQlUrl: process.env.GRAPHQL_API_URL,
     rootAccountRole: process.env.DISCOVERY_ROLE,

--- a/source/backend/discovery/src/lib/constants.js
+++ b/source/backend/discovery/src/lib/constants.js
@@ -86,6 +86,7 @@ module.exports = {
     ENI_SEARCH_DESCRIPTION_PREFIX: 'ES ', // this value is the same for both Opensearch and ES ENIs
     ENI_SEARCH_REQUESTER_ID: 'amazon-elasticsearch', // this value is the same for both Opensearch and ES ENIs
     IAM: 'iam',
+    ROLE: 'role',
     LAMBDA: 'lambda',
     GLOBAL: 'global',
     REGION: 'region',

--- a/source/backend/discovery/test/initialisation.js
+++ b/source/backend/discovery/test/initialisation.js
@@ -96,7 +96,7 @@ describe('initialisation', () => {
                 .then(() => {
                     throw new Error('Expected promise to be rejected but was fullfilled.')
                 })
-                .catch(err => assert.strictEqual(err.message, 'No accounts to scan') );
+                .catch(err => assert.strictEqual(err.message, 'No accounts to scan.') );
 
         });
 
@@ -131,7 +131,7 @@ describe('initialisation', () => {
                 .then(() => {
                     throw new Error('Expected promise to be rejected but was fullfilled.')
                 })
-                .catch(err => assert.strictEqual(err.message, 'No accounts to scan') );
+                .catch(err => assert.strictEqual(err.message, 'No accounts to scan.') );
 
         });
 
@@ -162,8 +162,91 @@ describe('initialisation', () => {
                 }
             };
 
-            const {accountsMap} = await initialise({...defaultMockAwsClient, ...mockAwsClient}, mockAppSync, defaultConfig);
-            assert.strictEqual(accountsMap.size, 1)
+            const {accounts} = await initialise({...defaultMockAwsClient, ...mockAwsClient}, mockAppSync, defaultConfig);
+            const accX = accounts.find(x => x.accountId === ACCOUNT_X);
+            const accY = accounts.find(x => x.accountId === ACCOUNT_Y);
+
+            assert.isFalse(accX.isIamRoleDeployed);
+            assert.isTrue(accY.isIamRoleDeployed);
+        });
+
+        it('should retrieve accounts when not in AWS Organization', async () => {
+            const mockAwsClient = {
+                createStsClient() {
+                    return {
+                        getCurrentCredentials: async () => {
+                            return {accessKeyId: 'accessKeyId', secretAccessKey: 'secretAccessKey', sessionToken: 'sessionToken'};
+                        },
+                        getCredentials: sinon.stub()
+                            .onFirstCall().resolves({accessKeyId: 'accessKeyIdX', secretAccessKey: 'secretAccessKeyX', sessionToken: 'sessionTokenX'})
+                            .onSecondCall().resolves({accessKeyId: 'accessKeyIdY', secretAccessKey: 'secretAccessKeyY', sessionToken: 'sessionTokenY'})
+                    }
+                },
+                createConfigServiceClient() {
+                    return {
+                        async getConfigAggregator() {
+                            return {
+                                OrganizationAggregationSource: {
+                                    AllAwsRegions: true
+                                }
+                            };
+                        }
+                    }
+                },
+                createEc2Client() {
+                    return {
+                        async getAllRegions() {
+                            return [{name: EU_WEST_1}, {name: US_EAST_1}]
+                        }
+                    };
+                }
+            };
+
+            const mockAppSync = () => {
+                return {
+                    createPaginator: async () => {},
+                    async getAccounts() {
+                        return [
+                            {accountId: ACCOUNT_X, name: 'Account X', regions: [{name: EU_WEST_1}, {name: US_EAST_1}]},
+                            {accountId: ACCOUNT_Y, name: 'Account Y', regions: [{name: EU_WEST_1}]}
+                        ]
+                    }
+                }
+            };
+
+            const {accounts} = await initialise({...defaultMockAwsClient, ...mockAwsClient}, mockAppSync, {
+                ...defaultConfig, isUsingOrganizations: false});
+            const accX = accounts.find(x => x.accountId === ACCOUNT_X);
+            const accY = accounts.find(x => x.accountId === ACCOUNT_Y);
+
+            assert.deepEqual(accX, {
+                accountId: ACCOUNT_X,
+                credentials: {
+                    accessKeyId: 'accessKeyIdX',
+                    secretAccessKey: 'secretAccessKeyX',
+                    sessionToken: 'sessionTokenX',
+                },
+                name: 'Account X',
+                isIamRoleDeployed: true,
+                regions: [
+                    EU_WEST_1,
+                    US_EAST_1
+                ]
+            });
+            assert.deepEqual(accY, {
+                accountId: ACCOUNT_Y,
+                credentials: {
+                    accessKeyId: 'accessKeyIdY',
+                    secretAccessKey: 'secretAccessKeyY',
+                    sessionToken: 'sessionTokenY',
+                },
+                name: 'Account Y',
+                isIamRoleDeployed: true,
+                regions: [
+                    EU_WEST_1
+                ]
+            });
+
         });
 
         it('should retrieve accounts from AWS Organizations', async () => {
@@ -215,13 +298,17 @@ describe('initialisation', () => {
 
             const mockAppSync = () => {
                 return {
-                    createPaginator: async () => {}
+                    createPaginator: async () => {},
+                    getAccounts: async () => []
                 }
             };
 
-            const {accountsMap} = await initialise({...defaultMockAwsClient, ...mockAwsClient}, mockAppSync, {
-                ...defaultConfig, crossAccountDiscovery: 'AWS_ORGANIZATIONS'});
-            assert.deepEqual(accountsMap.get(ACCOUNT_X), {
+            const {accounts} = await initialise({...defaultMockAwsClient, ...mockAwsClient}, mockAppSync, {
+                ...defaultConfig, isUsingOrganizations: true});
+            const accX = accounts.find(x => x.accountId === ACCOUNT_X);
+            const accY = accounts.find(x => x.accountId === ACCOUNT_Y);
+
+            assert.deepEqual(accX, {
                 accountId: ACCOUNT_X,
                 credentials: {
                     accessKeyId: 'accessKeyIdX',
@@ -230,12 +317,14 @@ describe('initialisation', () => {
                 },
                 name: 'Account X',
                 organizationId: 'o-exampleorgid',
+                isIamRoleDeployed: true,
+                isManagementAccount: true,
                 regions: [
                     EU_WEST_1,
                     US_EAST_1
                 ]
             });
-            assert.deepEqual(accountsMap.get(ACCOUNT_Y), {
+            assert.deepEqual(accY, {
                 accountId: ACCOUNT_Y,
                 credentials: {
                     accessKeyId: 'accessKeyIdY',
@@ -244,6 +333,109 @@ describe('initialisation', () => {
                 },
                 name: 'Account Y',
                 organizationId: 'o-exampleorgid',
+                isIamRoleDeployed: true,
+                isManagementAccount: false,
+                regions: [
+                    EU_WEST_1,
+                    US_EAST_1
+                ]
+            });
+
+        });
+
+        it('should add last crawled time to accounts from AWS Organizations', async () => {
+            const mockAwsClient = {
+                createStsClient() {
+                    return {
+                        getCurrentCredentials: async () => {
+                            return {accessKeyId: 'accessKeyId', secretAccessKey: 'secretAccessKey', sessionToken: 'sessionToken'};
+                        },
+                        getCredentials: sinon.stub()
+                            .onFirstCall().resolves({accessKeyId: 'accessKeyIdX', secretAccessKey: 'secretAccessKeyX', sessionToken: 'sessionTokenX'})
+                            .onSecondCall().resolves({accessKeyId: 'accessKeyIdY', secretAccessKey: 'secretAccessKeyY', sessionToken: 'sessionTokenY'})
+                    }
+                },
+                createConfigServiceClient() {
+                    return {
+                        async getConfigAggregator() {
+                            return {
+                                OrganizationAggregationSource: {
+                                    AllAwsRegions: true
+                                }
+                            };
+                        }
+                    }
+                },
+                createEc2Client() {
+                    return {
+                        async getAllRegions() {
+                            return [{name: EU_WEST_1}, {name: US_EAST_1}]
+                        }
+                    };
+                },
+                createOrganizationsClient() {
+                    return {
+                        async getAllAccounts() {
+                            return [
+                                {Id: ACCOUNT_X, Name: 'Account X', Arn: `arn:aws:organizations::${ACCOUNT_X}:account/o-exampleorgid/:${ACCOUNT_X}`},
+                                {Id: ACCOUNT_Y, Name: 'Account Y', Arn: `arn:aws:organizations:::${ACCOUNT_Y}:account/o-exampleorgid/:${ACCOUNT_Y}`}
+                            ]
+                        },
+                        async getRootAccount() {
+                            return {
+                                Arn: `arn:aws:organizations::${ACCOUNT_X}:account/o-exampleorgid/:${ACCOUNT_X}`
+                            }
+                        }
+                    }
+                }
+            };
+
+            const mockAppSync = () => {
+                return {
+                    createPaginator: async () => {},
+                    getAccounts: async () => [
+                        {
+                            accountId: ACCOUNT_X,
+                            name: 'Account X',
+                            lastCrawled: new Date('2022-10-25').toISOString(),
+                            regions: [{name: EU_WEST_1}, {name: US_EAST_1}]},
+                    ]
+                }
+            };
+
+            const {accounts} = await initialise({...defaultMockAwsClient, ...mockAwsClient}, mockAppSync, {
+                ...defaultConfig, isUsingOrganizations: true});
+            const accX = accounts.find(x => x.accountId === ACCOUNT_X);
+            const accY = accounts.find(x => x.accountId === ACCOUNT_Y);
+
+            assert.deepEqual(accX, {
+                accountId: ACCOUNT_X,
+                credentials: {
+                    accessKeyId: 'accessKeyIdX',
+                    secretAccessKey: 'secretAccessKeyX',
+                    sessionToken: 'sessionTokenX',
+                },
+                name: 'Account X',
+                organizationId: 'o-exampleorgid',
+                isIamRoleDeployed: true,
+                isManagementAccount: true,
+                lastCrawled: '2022-10-25T00:00:00.000Z',
+                regions: [
+                    EU_WEST_1,
+                    US_EAST_1
+                ]
+            });
+            assert.deepEqual(accY, {
+                accountId: ACCOUNT_Y,
+                credentials: {
+                    accessKeyId: 'accessKeyIdY',
+                    secretAccessKey: 'secretAccessKeyY',
+                    sessionToken: 'sessionTokenY',
+                },
+                name: 'Account Y',
+                organizationId: 'o-exampleorgid',
+                isIamRoleDeployed: true,
+                isManagementAccount: false,
                 regions: [
                     EU_WEST_1,
                     US_EAST_1

--- a/source/backend/functions/settings/src/index.js
+++ b/source/backend/functions/settings/src/index.js
@@ -64,10 +64,13 @@ const createBatchWriteRequest = (TableName) => (writes) => ({
 const getUnprocessedItems = (TableName) =>
     R.pathOr([], ['UnprocessedItems', TableName]);
 
+const accountProjectionExpression =
+    'accountId, #name, regions, isIamRoleDeployed, organizationId, isManagementAccount, lastCrawled';
+
 function getAccountsFromDb(docClient, TableName) {
     return Promise.resolve({
         KeyConditionExpression: 'PK = :PK',
-        ProjectionExpression: 'accountId, #name, regions',
+        ProjectionExpression: accountProjectionExpression,
         ExpressionAttributeNames:{
             '#name': 'name'
         },
@@ -192,7 +195,7 @@ function updateRegions(docClient, TableName, { accountId, regions }) {
 function getAccount(docClient, TableName, {accountId}) {
     return Promise.resolve({
         KeyConditionExpression: 'PK = :PK AND SK = :SK',
-        ProjectionExpression: 'accountId, #name, regions',
+        ProjectionExpression: accountProjectionExpression,
         ExpressionAttributeNames:{
             '#name': 'name'
         },

--- a/source/backend/functions/settings/test/index.js
+++ b/source/backend/functions/settings/test/index.js
@@ -281,6 +281,10 @@ describe('index.js', () => {
                             {
                                 accountId: '111111111111',
                                 name: 'test',
+                                isManagementAccount: true,
+                                isIamRoleDeployed: true,
+                                organizationId: 'test-org',
+                                lastCrawled: new Date('2011-06-21').toISOString(),
                                 regions: [
                                     {
                                         name: 'eu-west-1'
@@ -293,6 +297,10 @@ describe('index.js', () => {
                             {
                                 accountId: '222222222222',
                                 name: 'test',
+                                isManagementAccount: false,
+                                isIamRoleDeployed: true,
+                                organizationId: 'test-org',
+                                lastCrawled: new Date('2014-04-09').toISOString(),
                                 regions: [
                                     {
                                         name: 'us-east-1'
@@ -327,6 +335,10 @@ describe('index.js', () => {
                         name: 'test',
                         accountId: '111111111111',
                         PK: 'Account',
+                        isManagementAccount: true,
+                        isIamRoleDeployed: true,
+                        organizationId: 'test-org',
+                        lastCrawled: '2011-06-21T00:00:00.000Z',
                         regions: [
                             {
                                 name: 'eu-west-1'
@@ -342,6 +354,10 @@ describe('index.js', () => {
                         name: 'test',
                         accountId: '222222222222',
                         PK: 'Account',
+                        isManagementAccount: false,
+                        isIamRoleDeployed: true,
+                        organizationId: 'test-org',
+                        lastCrawled: '2014-04-09T00:00:00.000Z',
                         regions: [
                             {
                                 name: 'us-east-1'

--- a/source/backend/graphql/schema/perspective-api.graphql
+++ b/source/backend/graphql/schema/perspective-api.graphql
@@ -13,6 +13,8 @@ type Account @aws_cognito_user_pools @aws_iam {
   name: String
   # The AWS organization the account belongs to
   organizationId: String
+  isIamRoleDeployed: Boolean
+  isManagementAccount: Boolean
   # The regions AWS Perspective is enabled on
   regions: [Region]!
   lastCrawled: AWSDateTime
@@ -40,6 +42,8 @@ input AccountInput {
   name: String
   # The AWS organization the account belongs to
   organizationId: String
+  isIamRoleDeployed: Boolean
+  isManagementAccount: Boolean
   # The regions AWS Perspective is enabled on. For queries, if region is absent
   # then all regions will be returned
   regions: [RegionInput]
@@ -174,6 +178,7 @@ type Mutation {
     accountId: String!
     lastCrawled: AWSDateTime
     name: String
+    isIamRoleDeployed: Boolean
   ): AccountMetadata @aws_cognito_user_pools @aws_iam
   # Updates one or more regions to be scanned
   updateRegions(accountId: String!, regions: [RegionInput]!): Account

--- a/source/frontend/src/API/GraphQL/queries.js
+++ b/source/frontend/src/API/GraphQL/queries.js
@@ -244,6 +244,8 @@ export const getAccount = /* GraphQL */ `
     getAccount(accountId: $accountId) {
       accountId
       name
+      isIamRoleDeployed
+      isManagementAccount
       regions {
         name
         lastCrawled
@@ -257,6 +259,8 @@ export const getAccounts = /* GraphQL */ `
     getAccounts {
       accountId
       name
+      isIamRoleDeployed
+      isManagementAccount
       regions {
         name
         lastCrawled

--- a/source/frontend/src/components/RegionManagement/DiscoverableRegions/DiscoverableAccountsTable.js
+++ b/source/frontend/src/components/RegionManagement/DiscoverableRegions/DiscoverableAccountsTable.js
@@ -102,9 +102,9 @@ function matchesRoleStatus(item, selectedRoleStatus) {
     }
 }
 
-function downloadButton({globalTemplate}) {
+function DownloadButton({globalTemplate}) {
     return (
-        <Button onClick={async () =>
+        <Button iconName='download' onClick={async () =>
             fileDownload(
                 globalTemplate,
                 'global-resources.template'
@@ -118,7 +118,7 @@ function SelfManagedAccountsAlert({globalTemplate}) {
         <Alert
             type="warning"
             statusIconAriaLabel="Warning"
-            action={downloadButton({globalTemplate})}
+            action={DownloadButton({globalTemplate})}
             header="Undiscovered Accounts"
         >
             The global resources CloudFormation templates have not been deployed to one or more accounts. You must
@@ -154,7 +154,7 @@ function OrganizationsManagedAccounts({globalTemplate, accounts}) {
                 : <Alert
                     type="warning"
                     statusIconAriaLabel="Warning"
-                    action={downloadButton({globalTemplate})}
+                    action={DownloadButton({globalTemplate})}
                     header="Management Account Undiscovered"
                 >
                     The global resources CloudFormation template has not been deployed to the AWS Organizations management

--- a/source/frontend/src/components/RegionManagement/DiscoverableRegions/DiscoverableAccountsTable.js
+++ b/source/frontend/src/components/RegionManagement/DiscoverableRegions/DiscoverableAccountsTable.js
@@ -3,25 +3,27 @@
 
 import React, {useState} from 'react';
 import {
-  Box,
-  Button,
-  TextFilter,
-  Header,
-  Pagination,
-  Table,
-  SpaceBetween, Modal,
+    Box,
+    Button,
+    TextFilter,
+    Header,
+    Pagination,
+    Table,
+    SpaceBetween, Modal, StatusIndicator, Alert, Select, Grid,
 } from '@awsui/components-react';
 import PropTypes from 'prop-types';
 import { IMPORT } from '../../../routes';
 import { useCollection } from '@awsui/collection-hooks';
 import { useHistory } from 'react-router-dom';
 import {useAccounts, useRemoveAccount} from "../../Hooks/useAccounts";
+import {GLOBAL_TEMPLATE, useTemplate} from "../../Hooks/useTemplate";
 import dayjs  from 'dayjs';
 import localizedFormat  from 'dayjs/plugin/localizedFormat';
 import relativeTime  from 'dayjs/plugin/relativeTime';
 import * as R  from 'ramda';
 import {useDeepCompareEffect} from "react-use";
 import {isUsingOrganizations} from "../../../Utils/AccountUtils";
+import fileDownload from "js-file-download";
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
 
@@ -37,7 +39,7 @@ const columns = [
   {
     id: 'accountName',
     header: 'Account name',
-    cell: (e) => e.accountName,
+    cell: (e) => e.name,
     sortingField: 'accountName',
     width: 300,
     minWidth: 300,
@@ -46,14 +48,135 @@ const columns = [
     id: 'regions',
     header: 'Regions',
     cell: (e) => e.regionCount,
-    width: 200,
-    minWidth: 200,
+    width: 125,
+    minWidth: 125,
   },
+  {
+      id: 'iamRoleStatus',
+      header: 'Role Status',
+      cell: (e) => {
+          if(e.isIamRoleDeployed == null) return <StatusIndicator type='info'>Unknown</StatusIndicator>;
+          return e.isIamRoleDeployed === false
+              ? <StatusIndicator type='error'>Not Deployed</StatusIndicator>
+              : <StatusIndicator type='success'>Deployed</StatusIndicator>;
+      },
+      width: 200,
+      minWidth: 200,
+  },
+    {
+        id: 'lastDiscovered',
+        header: 'Last Discovered',
+        cell: (e) => {
+            if(e.isIamRoleDeployed === false && e.lastCrawled == null) {
+                return <StatusIndicator type='error'>Not Discoverable</StatusIndicator>;
+            } else if(e.isIamRoleDeployed == null) {
+                return <StatusIndicator type='info'>Awaiting Discovery</StatusIndicator>;
+            } else {
+                return dayjs().to(dayjs(e.lastCrawled))
+            }
+        },
+        width: 200,
+        minWidth: 200,
+    }
 ];
+
+const defaultRoleStatus = { value: '0', label: 'Any Role Status' };
+
+const selectRoleStatusOptions = [
+    defaultRoleStatus,
+    { value: '1', label: 'Unknown' },
+    { value: '2', label: 'Deployed' },
+    { value: '3', label: 'Not Deployed' }
+];
+
+function matchesRoleStatus(item, selectedRoleStatus) {
+    switch(selectedRoleStatus.label) {
+      case 'Unknown':
+        return item.isIamRoleDeployed == null;
+      case 'Deployed':
+        return item.isIamRoleDeployed === true;
+      case 'Not Deployed':
+        return item.isIamRoleDeployed === false;
+      default:
+        return true;
+    }
+}
+
+function downloadButton({globalTemplate}) {
+    return (
+        <Button onClick={async () =>
+            fileDownload(
+                globalTemplate,
+                'global-resources.template'
+            )
+        }>Download global resources template</Button>
+    );
+}
+
+function SelfManagedAccountsAlert({globalTemplate}) {
+    return (
+        <Alert
+            type="warning"
+            statusIconAriaLabel="Warning"
+            action={downloadButton({globalTemplate})}
+            header="Undiscovered Accounts"
+        >
+            The global resources CloudFormation templates have not been deployed to one or more accounts. You must
+            provision this template in these accounts to make them discoverable by Workload Discovery. You can filter
+            the account list by selecting <b>Not Deployed</b> from the Role Status dropdown menu to determine which
+            accounts must be updated. Choose <b>Download global resources template</b> and deploy the template in each
+            of the affected accounts.
+        </Alert>
+    );
+}
+
+function OrganizationsManagedAccounts({globalTemplate, accounts}) {
+    const managementAccount = accounts.find(x => x.isManagementAccount === true);
+    const noIamDeployedAccounts = accounts.filter(x => x.isIamRoleDeployed === false && !x.isManagementAccount);
+
+    return (
+        <SpaceBetween size="xxs">
+            {R.isEmpty(noIamDeployedAccounts)
+                ? void 0
+                : <Alert
+                    type="warning"
+                    statusIconAriaLabel="Warning"
+                    header="Undiscovered Accounts"
+                >
+                    The global resources CloudFormation templates have not been deployed to one or more accounts. These are
+                    provisioned by the <b>WdGlobalResources</b> StackSet in the account and region that Workload Discovery
+                    has been deployed to. Verify that all the stack instances in the <b>WdGlobalResources</b> StackSet have
+                    deployed successfully.
+                </Alert>
+            }
+            {managementAccount == null || managementAccount.isIamRoleDeployed === true
+                ? void 0
+                : <Alert
+                    type="warning"
+                    statusIconAriaLabel="Warning"
+                    action={downloadButton({globalTemplate})}
+                    header="Management Account Undiscovered"
+                >
+                    The global resources CloudFormation template has not been deployed to the AWS Organizations management
+                    account. You must provision this template to make this account discoverable by Workload Discovery.
+                    Choose <b>Download global resources template</b> and deploy the template to the management account.
+                </Alert>
+            }
+        </SpaceBetween>
+    );
+}
+
+function AccountAlert({globalTemplate, accounts}) {
+    return isUsingOrganizations()
+        ? <OrganizationsManagedAccounts globalTemplate={globalTemplate} accounts={accounts}/>
+        : <SelfManagedAccountsAlert globalTemplate={globalTemplate}/>
+}
 
 const DiscoverableAccountsTable = ({ selectedAccounts, onSelect }) => {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [roleStatus, setRoleStatus] = useState(defaultRoleStatus);
   const {data=[], isLoading} = useAccounts();
+  const {data: globalTemplate} = useTemplate(GLOBAL_TEMPLATE);
   const {removeAsync} = useRemoveAccount();
   const history = useHistory();
 
@@ -62,16 +185,18 @@ const DiscoverableAccountsTable = ({ selectedAccounts, onSelect }) => {
   }, [data, onSelect, selectedAccounts]);
 
   const accounts = R.map(
-    (acc) => ({
-        id:`${acc.accountId + acc.name}`,
-        accountId: acc.accountId,
-        accountName: acc.name,
-        regionCount: R.length(acc.regions),
-        lastCrawled: acc.lastCrawled,
-        regions: acc.regions,
+    ({accountId, name, regions, ...props}) => ({
+        id: accountId + name,
+        accountId,
+        name,
+        regionCount: R.length(regions),
+        regions,
+        ...props
     }),
     data
   )
+
+  const noIamDeployedAccounts = accounts.filter(x => !x.isIamRoleDeployed);
 
   const onSelectionChange = (items) => {
     onSelect(items);
@@ -100,6 +225,9 @@ const DiscoverableAccountsTable = ({ selectedAccounts, onSelect }) => {
           </Box>
         </Box>
       ),
+      filteringFunction: (item, filteringText) => {
+          return item.accountId.includes(filteringText) && matchesRoleStatus(item, roleStatus);
+      }
     },
     pagination: { pageSize: 10 },
     sorting: { sortingColumn: 'accountId' },
@@ -127,49 +255,70 @@ const DiscoverableAccountsTable = ({ selectedAccounts, onSelect }) => {
       >
         Remove the AWS account <strong>{selectedAccounts.map(i => R.defaultTo(i.accountId, i.accountName)).join(", ")}</strong>?
       </Modal>
-      <Table
-        {...collectionProps}
-        header={
-          <Header
-            actions={
-              isUsingOrganizations()
-                  ? void 0
-                  : <SpaceBetween direction='horizontal' size='xs'>
-                      <Button
-                          disabled={R.isEmpty(selectedAccounts)}
-                          onClick={() => setShowDeleteConfirm(true)}>
-                          Remove
-                      </Button>
-                      <Button
-                          loadingText='Removing'
-                          variant='primary'
-                          onClick={(e) => {
-                              e.preventDefault();
-                              history.push(IMPORT);
-                          }}>
-                          Import
-                      </Button>
-                  </SpaceBetween>
-            }
-            variant='h2'
-            description='AWS accounts that contain Regions imported into Workload Discovery on AWS'>
-            Accounts
-          </Header>
-        }
-        loading={isLoading}
-        trackBy={'id'}
-        resizableColumns
-        columnDefinitions={columns}
-        items={items}
-        selectedItems={selectedAccounts}
-        selectionType='multi'
-        onSelectionChange={(evt) => onSelectionChange(evt.detail.selectedItems)}
-        loadingText='Loading accounts'
-        filter={
-          <TextFilter {...filterProps} filteringPlaceholder='Find an Account...' />
-        }
-        pagination={<Pagination {...paginationProps} />}
-      />
+      <SpaceBetween size="s">
+          {R.isEmpty(noIamDeployedAccounts)
+              ? void 0
+              : <AccountAlert globalTemplate={globalTemplate} accounts={accounts}/>
+          }
+          <Table
+              {...collectionProps}
+              header={
+                  <Header
+                      actions={
+                          isUsingOrganizations()
+                              ? void 0
+                              : <SpaceBetween direction='horizontal' size='xs'>
+                                  <Button
+                                      disabled={R.isEmpty(selectedAccounts)}
+                                      onClick={() => setShowDeleteConfirm(true)}>
+                                      Remove
+                                  </Button>
+                                  <Button
+                                      loadingText='Removing'
+                                      variant='primary'
+                                      onClick={(e) => {
+                                          e.preventDefault();
+                                          history.push(IMPORT);
+                                      }}>
+                                      Import
+                                  </Button>
+                              </SpaceBetween>
+                      }
+                      variant='h2'
+                      description='AWS accounts that contain Regions imported into Workload Discovery on AWS'>
+                      Accounts
+                  </Header>
+              }
+              loading={isLoading}
+              trackBy={'id'}
+              resizableColumns
+              columnDefinitions={columns}
+              items={items}
+              selectedItems={selectedAccounts}
+              selectionType='multi'
+              onSelectionChange={(evt) => onSelectionChange(evt.detail.selectedItems)}
+              loadingText='Loading accounts'
+              filter={
+                  <Grid
+                      gridDefinition={[
+                          { colspan: { default: 3, xxs: 9 } },
+                          { colspan: { default: 9, xxs: 3 } }
+                      ]}
+                  >
+                      <TextFilter{...filterProps} filteringPlaceholder='Find an Account...'/>
+                      <Select
+                          options={selectRoleStatusOptions}
+                          selectedAriaLabel="Selected"
+                          selectedOption={roleStatus}
+                          onChange={event => setRoleStatus(event.detail.selectedOption)}
+                          ariaDescribedby={null}
+                          expandToViewport={true}
+                      />
+                  </Grid>
+              }
+              pagination={<Pagination {...paginationProps} />}
+          />
+      </SpaceBetween>
     </>
   );
 };

--- a/source/frontend/src/components/RegionManagement/DiscoverableRegions/DiscoverableAccountsTable.js
+++ b/source/frontend/src/components/RegionManagement/DiscoverableRegions/DiscoverableAccountsTable.js
@@ -24,6 +24,7 @@ import * as R  from 'ramda';
 import {useDeepCompareEffect} from "react-use";
 import {isUsingOrganizations} from "../../../Utils/AccountUtils";
 import fileDownload from "js-file-download";
+import {GLOBAL_RESOURCES_TEMPLATE_FILENAME} from "../../../config/constants";
 dayjs.extend(localizedFormat);
 dayjs.extend(relativeTime);
 
@@ -107,7 +108,7 @@ function DownloadButton({globalTemplate}) {
         <Button iconName='download' onClick={async () =>
             fileDownload(
                 globalTemplate,
-                'global-resources.template'
+                GLOBAL_RESOURCES_TEMPLATE_FILENAME
             )
         }>Download global resources template</Button>
     );

--- a/source/frontend/src/components/RegionManagement/SinglePageImport/TemplateProvider.js
+++ b/source/frontend/src/components/RegionManagement/SinglePageImport/TemplateProvider.js
@@ -10,6 +10,7 @@ import {
 import {GLOBAL_TEMPLATE, REGIONAL_TEMPLATE, useTemplate} from "../../Hooks/useTemplate";
 
 import fileDownload from 'js-file-download';
+import {GLOBAL_RESOURCES_TEMPLATE_FILENAME} from "../../../config/constants";
 
 const TemplateProvider = () => {
   const {data: globalTemplate, isLoading: isLoadingGlobal} = useTemplate(GLOBAL_TEMPLATE);
@@ -34,7 +35,7 @@ const TemplateProvider = () => {
               onClick={async () =>
                 fileDownload(
                   globalTemplate,
-                  'global-resources.template'
+                    GLOBAL_RESOURCES_TEMPLATE_FILENAME
                 )
               }>
               Global Resources

--- a/source/frontend/src/config/constants.js
+++ b/source/frontend/src/config/constants.js
@@ -1,1 +1,2 @@
 export const AWS_ORGANIZATIONS = 'AWS_ORGANIZATIONS';
+export const GLOBAL_RESOURCES_TEMPLATE_FILENAME = 'global-resources.template'


### PR DESCRIPTION
Issue #, if available:
Closes #367. Completes #1.

Description of changes:

This pull requests implements changes on the frontend to display to users if the global resources template has been deployed to accounts that have been added to Workload Discovery. This also required changes on that backend to catch failures when attempting to assume the IAM role provisioned by the global resources template and persist them in the database that stores accounts.

If the IAM role has not been deployed, the UI will present a warning with remediation steps. These steps will be different depending on whether the solution has been deployed with the AWS Organizations integration or not.

Self-managed Account Discovery:

<img width="1145" alt="SelfManagedIamDeploy" src="https://user-images.githubusercontent.com/8573472/216304354-f55c3a1c-ebbe-47e2-9d65-078075e3ff63.png">

AWS Organizations Account Discovery:

<img width="1147" alt="OrganizationsIamDeployed" src="https://user-images.githubusercontent.com/8573472/216304062-9c62d854-1de0-409e-bc36-14dfacb017de.png">


