### PR TITLE
Fix json export functionality

### DIFF
--- a/source/frontend/src/components/Diagrams/Draw/Canvas/Export/JSON/CreateJSONExport.js
+++ b/source/frontend/src/components/Diagrams/Draw/Canvas/Export/JSON/CreateJSONExport.js
@@ -1,12 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-export const exportJSON = (canvas) => {
-  const nodes = canvas.nodes().jsons();
-  const edges =  canvas.elements().filter(function(element){
-    return element.isEdge()
-  });
-  return new Blob([JSON.stringify({ nodes: nodes, edges: edges.jsons()})], {
+export const exportJSON = (diagramData) => {
+  return new Blob([JSON.stringify(diagramData)], {
     type: 'application/json;charset=utf-8',
   });
 };


### PR DESCRIPTION
Issue #, if available:
Fixes #336 

Description of changes:
The old implementation uses the canvas Cytoscape object directly to get the nodes and edges but now that processing is done before calling the export function.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.