### PR TITLE
Fix Load Costs date interval issue

### DIFF
--- a/source/frontend/src/components/Diagrams/Draw/DrawDiagram/DiagramControlsPanel.js
+++ b/source/frontend/src/components/Diagrams/Draw/DrawDiagram/DiagramControlsPanel.js
@@ -47,7 +47,7 @@ const DiagramControlPanel = ({
   const [statusMessage, setStatusMessage] = useState();
   const [hasLoadedCosts, setHasLoadedCosts] = useState(false);
   const [loadingCosts, setLoadingCosts] = useState(false);
-  const { endDate=today, startDate=fiveDaysAgo } = settings?.costsInterval ?? {};
+  const { endDate=today, startDate=fiveDaysAgo } = settings?.costInterval ?? {};
   const {removeAsync} = useRemoveObject(diagramsPrefix);
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
   const previousResources = usePrevious(resources);


### PR DESCRIPTION
Description of changes:
There was a typo in the variable name that holds the date interval value when load costs onto the diagram. This meant that the default interval (five days) was always used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
