### PR TITLE
Add pagination to getResourcesGraph

### DIFF
--- a/source/backend/functions/graph-api/package-lock.json
+++ b/source/backend/functions/graph-api/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "wd-graph-api",
       "version": "2.0.0",
-      "license": "ISC",
+      "license": "Apache-2.0",
       "dependencies": {
         "@supercharge/promise-pool": "2.3.2",
         "gremlin": "3.5.2",

--- a/source/backend/functions/graph-api/test/index.js
+++ b/source/backend/functions/graph-api/test/index.js
@@ -22,6 +22,7 @@ describe('index.js', () => {
                 V: sinon.stub().returnsThis(),
                 with_: sinon.stub().returnsThis(),
                 aggregate: sinon.stub().returnsThis(),
+                cap: sinon.stub().returnsThis(),
                 addE: sinon.stub().returnsThis(),
                 by: sinon.stub().returnsThis(),
                 both: sinon.stub().returnsThis(),


### PR DESCRIPTION
Description of changes:

Previously, the pagination parameter was being ignored in the Gremlin lambda resolver function. It will now apply to both the `nodes` and `edges` fields returned. When both fields return an empty array then the client will know the pagination has completed.
