### PR TITLE
Memoize throttler creation

### DIFF
--- a/source/backend/discovery/src/lib/additionalRelationships/addIndividualRelationships.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/addIndividualRelationships.js
@@ -470,7 +470,7 @@ function createIndividualHandlers(lookUpMaps, awsClient) {
         },
         [AWS_ELASTIC_LOAD_BALANCING_LOADBALANCER]: async ({resourceId, accountId, awsRegion, relationships}) => {
             const {credentials} = accountsMap.get(accountId);
-            const elbClient = awsClient.createElbClient(accountId, credentials, awsRegion);
+            const elbClient = awsClient.createElbClient(credentials, awsRegion);
 
             const instanceIds = await elbClient.getLoadBalancerInstances(resourceId);
 
@@ -495,7 +495,7 @@ function createIndividualHandlers(lookUpMaps, awsClient) {
         },
         [AWS_ELASTIC_LOAD_BALANCING_V2_TARGET_GROUP]: async ({accountId, awsRegion, arn, configuration: {VpcId}, relationships}) => {
             const {credentials} = accountsMap.get(accountId);
-            const elbClientV2 = awsClient.createElbV2Client(accountId, credentials, awsRegion);
+            const elbClientV2 = awsClient.createElbV2Client(credentials, awsRegion);
 
             const {instances: asgInstances, arn: asgArn} = targetGroupToAsgMap.get(arn) ?? {instances: new Set()};
 

--- a/source/backend/discovery/src/lib/awsClient.js
+++ b/source/backend/discovery/src/lib/awsClient.js
@@ -119,12 +119,12 @@ function createApiGatewayClient(credentials, region) {
     }
 
     // The API Gateway rate limits are _per account_ so we set the region to global
-    const getResourcesThrottler = createThrottler('getResources', credentials, GLOBAL, {
+    const getResourcesThrottler = createThrottler('apiGatewayGetResources', credentials, GLOBAL, {
         limit: 5,
         interval: 2000
     });
 
-    const totalOperationsThrottler = createThrottler('totalOperations', credentials, GLOBAL, {
+    const totalOperationsThrottler = createThrottler('apiGatewayTotalOperations', credentials, GLOBAL, {
         limit: 10,
         interval: 1000
     });
@@ -370,7 +370,7 @@ function createEksClient(credentials, region) {
         pageSize: 100
     };
     // this API only has a TPS of 10 so we set it artificially low to avoid rate limiting
-    const describeNodegroupThrottler = createThrottler('describeNodegroup', credentials, region, {
+    const describeNodegroupThrottler = createThrottler('eksDescribeNodegroup', credentials, region, {
         limit: 5,
         interval: 1000
     });
@@ -526,7 +526,7 @@ function createCognitoClient(credentials, region) {
 
     // describeUserPool has an RPS of 15, we set this artificially low to avoid
     // being rate limited
-    const describeUserPoolThrottler = createThrottler('describeUserPool', credentials, region, {
+    const describeUserPoolThrottler = createThrottler('cognitoDescribeUserPool', credentials, region, {
         limit: 7,
         interval: 1000
     });
@@ -553,14 +553,16 @@ function createDynamoDBStreamsClient(credentials, region) {
     const dynamoDBStreamsClient = new DynamoDBStreams({customUserAgent, region, credentials});
 
     // this API only has a TPS of 10 so we set it artificially low to avoid rate limiting
-    const describeStreamThrottler = createThrottler('describeStream', credentials, region, {
+    const describeStreamThrottler = createThrottler('dynamoDbDescribeStream', credentials, region, {
         limit: 8,
         interval: 1000
     });
 
+    const describeStream = describeStreamThrottler(streamArn => dynamoDBStreamsClient.describeStream({StreamArn: streamArn}));
+
     return {
         async describeStream(streamArn) {
-            const {StreamDescription} = await describeStreamThrottler(streamArn => dynamoDBStreamsClient.describeStream({StreamArn: streamArn}));
+            const {StreamDescription} = await describeStream(streamArn);
             return StreamDescription;
         }
     }

--- a/source/backend/discovery/src/lib/awsClient.js
+++ b/source/backend/discovery/src/lib/awsClient.js
@@ -53,19 +53,14 @@ const {
     DynamoDBStreams
 } = require('@aws-sdk/client-dynamodb-streams')
 const {SNSClient, paginateListSubscriptions} = require('@aws-sdk/client-sns');
+const {memoize} = require('./utils');
 
-// The API Gateway rate limits are _per account_ so we have to create any
-// throttlers outside the factory function
-const apiGatewayThrottlers = {
-    getResourcesThrottlers: new Map(),
-    totalOperationsThrottlers: new Map()
-}
-
-// The ELB rate limits are for all LB type so we have to create any
-// throttlers outside the ELB and ELBv2 factory functions
-const elbThrottlers = {
-    describeThrottlers: new Map()
-}
+// We want to share throttling limits across instances of clients so we memoize this
+// function that each factory function calls to create its throttlers during
+// instantiation.
+const createThrottler = memoize((name, credentials, region, throttleParams) => {
+    return pThrottle(throttleParams);
+});
 
 function createOrganizationsClient(credentials, region) {
     const organizationsClient = new Organizations({customUserAgent, region, credentials});
@@ -123,24 +118,16 @@ function createApiGatewayClient(accountId, credentials, region) {
         client: new APIGatewayClient({customUserAgent, region, credentials})
     }
 
-    const {getResourcesThrottlers, totalOperationsThrottlers} = apiGatewayThrottlers;
+    // The API Gateway rate limits are _per account_ so we set the region to global
+    const getResourcesThrottler = createThrottler('getResources', credentials, 'global', {
+        limit: 5,
+        interval: 2000
+    });
 
-    if (!getResourcesThrottlers.has(accountId)) {
-        getResourcesThrottlers.set(accountId, pThrottle({
-            limit: 5,
-            interval: 2000
-        }))
-    }
-
-    if (!totalOperationsThrottlers.has(accountId)) {
-        totalOperationsThrottlers.set(accountId, pThrottle({
-            limit: 10,
-            interval: 1000
-        }))
-    }
-
-    const getResourcesThrottler = getResourcesThrottlers.get(accountId);
-    const totalOperationsThrottler = totalOperationsThrottlers.get(accountId);
+    const totalOperationsThrottler = createThrottler('totalOperations', credentials, 'global', {
+        limit: 10,
+        interval: 1000
+    });
 
     return {
         getResources: totalOperationsThrottler(getResourcesThrottler(async restApiId => {
@@ -172,10 +159,12 @@ function createConfigServiceClient(credentials, region) {
         pageSize: 100
     };
 
-    const batchGetAggregateResourceConfigThrottler = pThrottle({
-        limit: 15,
-        interval: 1000
-    });
+    const batchGetAggregateResourceConfigThrottler = createThrottler(
+        'batchGetAggregateResourceConfig', credentials, region, {
+            limit: 15,
+            interval: 1000
+        }
+    );
 
     const batchGetAggregateResourceConfig = batchGetAggregateResourceConfigThrottler((ConfigurationAggregatorName, ResourceIdentifiers) => {
         return configClient.batchGetAggregateResourceConfig({ConfigurationAggregatorName, ResourceIdentifiers})
@@ -314,23 +303,17 @@ function createEcsClient(credentials, region) {
         pageSize: 100
     };
 
-    // describeContainerInstances and describeTasks share the same throttling bucket,
-    // the refill rate is 20 so we split it evenly between them
-    const describeContainerInstancesThrottler = pThrottle({
-        limit: 10,
+    // describeContainerInstances and describeTasks share the same throttling bucket
+    const ecsDescribeThrottler = createThrottler('ecsDescribe', credentials, region, {
+        limit: 20,
         interval: 1000
     });
 
-    const describeTasksThrottler = pThrottle({
-        limit: 10,
-        interval: 1000
-    });
-
-    const describeContainerInstances = describeContainerInstancesThrottler((cluster, containerInstances) => {
+    const describeContainerInstances = ecsDescribeThrottler((cluster, containerInstances) => {
         return ecsClient.describeContainerInstances({cluster, containerInstances});
     })
 
-    const describeTasks = describeTasksThrottler((cluster, tasks) => {
+    const describeTasks = ecsDescribeThrottler((cluster, tasks) => {
         return ecsClient.describeTasks({cluster, tasks});
     })
 
@@ -387,7 +370,7 @@ function createEksClient(credentials, region) {
         pageSize: 100
     };
     // this API only has a TPS of 10 so we set it artificially low to avoid rate limiting
-    const describeNodegroupThrottler = pThrottle({
+    const describeNodegroupThrottler = createThrottler('describeNodegroup', credentials, region, {
         limit: 5,
         interval: 1000
     });
@@ -415,30 +398,17 @@ function createEksClient(credentials, region) {
 
 }
 
-// this function mutates the elbThrottlers variable
-function getElbDescribeThrottler(elbThrottlers, accountId, region) {
-    if(!elbThrottlers.describeThrottlers.has(accountId)) {
-        elbThrottlers.describeThrottlers.set(accountId, new Map());
-    }
-
-    if(!elbThrottlers.describeThrottlers.get(accountId).has(region)) {
-        elbThrottlers.describeThrottlers.get(accountId).set(region, pThrottle({
-            limit: 10,
-            interval: 1000
-        }));
-    }
-
-    return elbThrottlers.describeThrottlers.get(accountId).get(region);
-}
-
-function createElbClient(accountId, credentials, region) {
+function createElbClient(credentials, region) {
     const elbClient = new ElasticLoadBalancing({credentials, region});
 
     // ELB rate limits for describe* calls are shared amongst all LB types
-    const describeThrottler = getElbDescribeThrottler(elbThrottlers, accountId, region);
+    const elbDescribeThrottler = createThrottler('elbDescribe', credentials, region, {
+        limit: 10,
+        interval: 1000
+    });
 
     return {
-        getLoadBalancerInstances: describeThrottler(async resourceId => {
+        getLoadBalancerInstances: elbDescribeThrottler(async resourceId => {
             const lb = await elbClient.describeLoadBalancers({
                 LoadBalancerNames: [resourceId],
             });
@@ -450,7 +420,7 @@ function createElbClient(accountId, credentials, region) {
     };
 }
 
-function createElbV2Client(accountId, credentials, region) {
+function createElbV2Client(credentials, region) {
     const elbClientV2 = new ElasticLoadBalancingV2({credentials, region});
     const elbV2PaginatorConfig = {
         client: new ElasticLoadBalancingV2Client({customUserAgent, region, credentials}),
@@ -458,16 +428,19 @@ function createElbV2Client(accountId, credentials, region) {
     };
 
     // ELB rate limits for describe* calls are shared amongst all LB types
-    const describeThrottler = getElbDescribeThrottler(elbThrottlers, accountId, region);
+    const elbDescribeThrottler = createThrottler('elbDescribe', credentials, region, {
+        limit: 10,
+        interval: 1000
+    });
 
     return {
-        describeTargetHealth: describeThrottler(async arn => {
+        describeTargetHealth: elbDescribeThrottler(async arn => {
             const {TargetHealthDescriptions = []} = await elbClientV2.describeTargetHealth({
                 TargetGroupArn: arn
             });
             return TargetHealthDescriptions;
         }),
-        getAllTargetGroups: describeThrottler(async () => {
+        getAllTargetGroups: elbDescribeThrottler(async () => {
             const tgPaginator = paginateDescribeTargetGroups(elbV2PaginatorConfig, {});
 
             const targetGroups = [];
@@ -553,7 +526,7 @@ function createCognitoClient(credentials, region) {
 
     // describeUserPool has an RPS of 15, we set this artificially low to avoid
     // being rate limited
-    const describeUserPoolThrottler = pThrottle({
+    const describeUserPoolThrottler = createThrottler('describeUserPool', credentials, region, {
         limit: 7,
         interval: 1000
     });

--- a/source/backend/discovery/src/lib/intialisation.js
+++ b/source/backend/discovery/src/lib/intialisation.js
@@ -126,7 +126,7 @@ async function initialise(awsClient, appSync, config) {
         throw new Error(DISCOVERY_PROCESS_RUNNING);
     }
 
-    const configServiceClient = awsClient.createConfigServiceClient(credentials, region)
+    const configServiceClient = awsClient.createConfigServiceClient(credentials, region);
 
     const appSyncClient = appSync({...config, creds: credentials});
     const apiClient = createApiClient(appSyncClient);

--- a/source/backend/discovery/src/lib/sdkResources/createAllBatchResources.js
+++ b/source/backend/discovery/src/lib/sdkResources/createAllBatchResources.js
@@ -45,7 +45,7 @@ async function createAttachedAwsManagedPolices(awsClient, credentials, accountId
 }
 
 async function createTargetGroups(awsClient, credentials, accountId, region) {
-    const elbV2Client = awsClient.createElbV2Client(accountId, credentials, region);
+    const elbV2Client = awsClient.createElbV2Client(credentials, region);
 
     const targetGroups = await elbV2Client.getAllTargetGroups();
 

--- a/source/backend/discovery/src/lib/sdkResources/firstOrderHandlers.js
+++ b/source/backend/discovery/src/lib/sdkResources/firstOrderHandlers.js
@@ -58,7 +58,7 @@ module.exports = {
                 const {id: RestApiId} = configuration;
                 const {credentials} = accountsMap.get(accountId);
 
-                const apiGatewayClient = awsClient.createApiGatewayClient(accountId, credentials, awsRegion);
+                const apiGatewayClient = awsClient.createApiGatewayClient(credentials, awsRegion);
 
                 const apiGatewayResources = []
 
@@ -104,7 +104,7 @@ module.exports = {
 
                 return apiGatewayResources;
             },
-            [AWS_DYNAMODB_TABLE]: async ({awsRegion, resourceId, resourceName, accountId, configuration}) => {
+            [AWS_DYNAMODB_TABLE]: async ({awsRegion, accountId, configuration}) => {
                 if (configuration.latestStreamArn == null) {
                     return []
                 }
@@ -125,7 +125,6 @@ module.exports = {
                         resourceName: streamInfo.StreamARN,
                         relationships: []
                     }, streamInfo)];
-                ;
             },
             [AWS_ECS_SERVICE]: async ({awsRegion, resourceId, resourceName, accountId, configuration: {Cluster}}) => {
                 const {credentials} = accountsMap.get(accountId);

--- a/source/backend/discovery/src/lib/sdkResources/secondOrderHandlers.js
+++ b/source/backend/discovery/src/lib/sdkResources/secondOrderHandlers.js
@@ -28,7 +28,7 @@ module.exports = {
 
                 const {credentials} = accountsMap.get(accountId);
 
-                const apiGatewayClient = awsClient.createApiGatewayClient(accountId, credentials, awsRegion);
+                const apiGatewayClient = awsClient.createApiGatewayClient(credentials, awsRegion);
 
                 const results = await Promise.allSettled([
                     apiGatewayClient.getMethod(POST, ResourceId, RestApiId),

--- a/source/backend/discovery/src/lib/utils.js
+++ b/source/backend/discovery/src/lib/utils.js
@@ -157,6 +157,8 @@ function profileAsync(message, f) {
     }
 }
 
+const memoize = R.memoizeWith((...args) => JSON.stringify(args));
+
 module.exports = {
     createContainsRelationship: createRelationship(CONTAINS),
     createAssociatedRelationship: createRelationship(IS_ASSOCIATED_WITH),
@@ -176,5 +178,6 @@ module.exports = {
     createResourceNameKey,
     createResourceIdKey,
     safeForEach: R.curry(safeForEach),
-    profileAsync: R.curry(profileAsync)
+    profileAsync: R.curry(profileAsync),
+    memoize
 }

--- a/source/backend/discovery/test/getAllSdkResources.js
+++ b/source/backend/discovery/test/getAllSdkResources.js
@@ -753,7 +753,7 @@ describe('getAllSdkResources', () => {
                 const {restApi, apiGwResource} = generate(schema);
 
                 const mockApiGatewayClient = {
-                    createApiGatewayClient(accountId, credentials, region) {
+                    createApiGatewayClient(credentials, region) {
                         return {
                             getAuthorizers: async restApi => [],
                             async getResources() {
@@ -840,7 +840,7 @@ describe('getAllSdkResources', () => {
                 const {restApi, apiGwResource, getMethod, postMethod} = generate(schema);
 
                 const mockApiGatewayClient = {
-                    createApiGatewayClient(accountId, credentials, region) {
+                    createApiGatewayClient(credentials, region) {
                         return {
                             getResources: async restApi => {
                                 if(credentials.accessKeyId === ACCESS_KEY_X && region === EU_WEST_2) {
@@ -935,7 +935,7 @@ describe('getAllSdkResources', () => {
                 const {restApi, apiGwAuthorizer} = generate(schema);
 
                 const mockApiGatewayClient = {
-                    createApiGatewayClient(accountId, credentials, region) {
+                    createApiGatewayClient(credentials, region) {
                         return {
                             getResources: async restApi => [],
                             async getAuthorizers(restApi) {
@@ -984,7 +984,7 @@ describe('getAllSdkResources', () => {
                 const {restApi, cognito, apiGwAuthorizer} = generate(schema);
 
                 const mockApiGatewayClient = {
-                    createApiGatewayClient(accountId, credentials, region) {
+                    createApiGatewayClient(credentials, region) {
                         return {
                             getResources: async restApi => [],
                             async getAuthorizers(restApi) {

--- a/source/backend/discovery/test/getAllSdkResources.js
+++ b/source/backend/discovery/test/getAllSdkResources.js
@@ -347,7 +347,7 @@ describe('getAllSdkResources', () => {
                 const {euWest2, usWest2} = require('./fixtures/additionalResources/alb/targetGroups.json');
 
                 const mockElbV2Client = {
-                    createElbV2Client(accountId, credentials, region) {
+                    createElbV2Client(credentials, region) {
                         return {
                             describeTargetHealth: async arn => [],
                             async getAllTargetGroups() {
@@ -406,10 +406,10 @@ describe('getAllSdkResources', () => {
             });
 
             it('should discover ALB target groups when some regions fail', async () => {
-                const {euWest2, usWest2} = require('./fixtures/additionalResources/alb/targetGroups.json');
+                const {euWest2} = require('./fixtures/additionalResources/alb/targetGroups.json');
 
                 const mockElbV2Client = {
-                    createElbV2Client(accountId, credentials, region) {
+                    createElbV2Client(credentials, region) {
                         return {
                             describeTargetHealth: async arn => [],
                             async getAllTargetGroups() {
@@ -456,7 +456,7 @@ describe('getAllSdkResources', () => {
             it('should discover spot instances', async () => {
                 const {instanceRequests} = require('./fixtures/additionalResources/spot/instance.json');
 
-                const mockEc2lient = {
+                const mockEc2Client = {
                     createEc2Client(credentials, region) {
                         return {
                             async getAllSpotInstanceRequests() {
@@ -482,7 +482,7 @@ describe('getAllSdkResources', () => {
                 const instanceId1 = "instanceId1";
                 const instanceId2 = "instanceId2";
 
-                const actual = await getAllSdkResources({...mockAwsClient, ...mockEc2lient}, []);
+                const actual = await getAllSdkResources({...mockAwsClient, ...mockEc2Client}, []);
 
                 const actualSpotFleet1 = actual.find(x => x.arn === arn1);
                 const actualSpotFleet2 = actual.find(x => x.arn === arn2);


### PR DESCRIPTION
Description of changes:

When creating instances of an SDK client for a particular region, we were creating a throttler on instantiation. This meant that if we have several instances of the same client for a region they would all be using different throttlers. For throttling to work, all instances of the client must share the same throttler so the number of requests stays below the limits we've set. This change, creates a function that creates throttlers but is memoized so that if a client is instantiated with the same name, credentials, region and throttling parameters that it will return a previously created throttling instance (should it exist).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
