### PR TITLE
Get EFS resources from Advanced Query API

### DIFF
--- a/source/backend/discovery/src/lib/aggregator/getAllConfigResources.js
+++ b/source/backend/discovery/src/lib/aggregator/getAllConfigResources.js
@@ -23,8 +23,6 @@ const {createArnWithResourceType, isDate, isString, isObject, objToKeyNameArray}
 
 const unsupportedResourceTypes = [
     AWS_KINESIS_STREAM,
-    AWS_EFS_ACCESS_POINT,
-    AWS_EFS_FILE_SYSTEM,
     AWS_EC2_LAUNCH_TEMPLATE,
     AWS_EC2_TRANSIT_GATEWAY,
     AWS_EC2_TRANSIT_GATEWAY_ATTACHMENT,


### PR DESCRIPTION
Description of changes:

AWS Config announced support for EFS resource types from the Advanced Query API, we no longer need to retrieve these types from the `ListAggregateDiscoveredResources` API now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
