### PR TITLE
fix dynamodb stream ARN field casing

### DIFF
--- a/source/backend/discovery/src/lib/additionalRelationships/addIndividualRelationships.js
+++ b/source/backend/discovery/src/lib/additionalRelationships/addIndividualRelationships.js
@@ -244,7 +244,7 @@ function createIndividualHandlers(lookUpMaps, awsClient) {
         [AWS_DYNAMODB_TABLE]: async dbTable => {
             const {configuration, relationships} = dbTable;
 
-            if (configuration.latestStreamArn) {
+            if (configuration.latestStreamArn != null) {
                 relationships.push(createAssociatedRelationship(AWS_DYNAMODB_STREAM, {arn: configuration.latestStreamArn}));
             }
         },

--- a/source/backend/discovery/src/lib/sdkResources/firstOrderHandlers.js
+++ b/source/backend/discovery/src/lib/sdkResources/firstOrderHandlers.js
@@ -113,18 +113,18 @@ module.exports = {
 
                 const dynamoDBStreamsClient = awsClient.createDynamoDBStreamsClient(credentials, awsRegion);
                 
-                const streamInfo = await dynamoDBStreamsClient.describeStream(configuration.latestStreamArn);
+                const stream = await dynamoDBStreamsClient.describeStream(configuration.latestStreamArn);
 
                 return [createConfigObject({
-                        arn: streamInfo.StreamARN,
+                        arn: stream.StreamArn,
                         accountId,
                         awsRegion,
                         availabilityZone: NOT_APPLICABLE,
                         resourceType: AWS_DYNAMODB_STREAM,
-                        resourceId: streamInfo.StreamARN,
-                        resourceName: streamInfo.StreamARN,
+                        resourceId: stream.StreamArn,
+                        resourceName: stream.StreamArn,
                         relationships: []
-                    }, streamInfo)];
+                    }, stream)];
             },
             [AWS_ECS_SERVICE]: async ({awsRegion, resourceId, resourceName, accountId, configuration: {Cluster}}) => {
                 const {credentials} = accountsMap.get(accountId);

--- a/source/backend/discovery/test/getAllSdkResources.js
+++ b/source/backend/discovery/test/getAllSdkResources.js
@@ -1565,7 +1565,7 @@ describe('getAllSdkResources', () => {
                             return {
                                 async describeStream(streamArn) {
                                     if(credentials.accessKeyId === ACCESS_KEY_X && region === EU_WEST_2) {
-                                        return { StreamARN: stream.arn }
+                                        return { StreamArn: stream.arn }
                                     }
                                 }
                             }
@@ -1588,7 +1588,7 @@ describe('getAllSdkResources', () => {
                         resourceType: AWS_DYNAMODB_STREAM,
                         relationships: [],
                         configuration: {
-                            StreamARN: "arn:aws:dynamodb:eu-west-2:xxxxxxxxxxxx:table/test/stream"
+                            StreamArn: "arn:aws:dynamodb:eu-west-2:xxxxxxxxxxxx:table/test/stream"
                         },
                         configurationItemStatus: "ResourceDiscovered",
                         tags: []


### PR DESCRIPTION
Description of changes:

The field containing the DynamoDb Stream ARN returned by the `describeStream` is `StreamArn` not `StreamARN`. This fixes the null value that was being used for the resource types ARN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
