### PR TITLE
update to v2.3.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /templates
 **/settings.js
 **/packaged.template
+build
 
 # dependencies
 **/node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project are documented in this file.
 Based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2025-07-21
+
+### Added
+
+- `AWS::EC2::Volume` -> `AWS::EC2::VPC`/`AWS::EC2::Subnet` relationships
+
+### Fixed
+
+- Workload Discovery ECS tasks failing with AWS Config errors [593](https://github.com/aws-solutions/workload-discovery-on-aws/issues/593)
+
+### Changed
+
+- `AWS::Bedrock::KnowledgeBase` resource type is now discovered via AWS Config
+- Update Neptune Engine version to `1.4.5.1`.
+
 ## [2.3.0] - 2025-07-02
 
 ### Added
@@ -12,15 +27,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - New resource types include:
   - `AWS::Bedrock::Agent`
   - `AWS::Bedrock::AgentVersion`
-  - `AWS::Bedrock::CustomModel` 
+  - `AWS::Bedrock::CustomModel`
   - `AWS::Bedrock::DataSource`
-  - `AWS::Bedrock::FoundationModel` 
-  - `AWS::Bedrock::ImportedModel` 
-  - `AWS::Bedrock::InferenceProfile` 
+  - `AWS::Bedrock::FoundationModel`
+  - `AWS::Bedrock::ImportedModel`
+  - `AWS::Bedrock::InferenceProfile`
   - `AWS::Bedrock::KnowledgeBase`
   - `AWS::Glue::Connection`
-  - `AWS::Glue::Crawler` 
-  - `AWS::Glue::Database` 
+  - `AWS::Glue::Crawler`
+  - `AWS::Glue::Database`
   - `AWS::Glue::Table`
   - `AWS::OpenSearchServerless::Collection`
 - New relationships include:
@@ -32,13 +47,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `AWS::Bedrock::KnowledgeBase` -> `AWS::IAM::Role`/`AWS::Kendra::Index`/`AWS::RDS::DBCluster`/`AWS::OpenSearchServerless::Collection`/`AWS::S3::Bucket`/`AWS::Redshift::Cluster`
   - `AWS::Glue::Connection` -> `AWS::EC2::Subnet`/`AWS::EC2::SecurityGroup`/`AWS::EC2::Instance`/`AWS::SecretsManager::Secret`/`AWS::IAM::Role`/`AWS::Glue::Connection`
   - `AWS::Glue::Crawler` -> `AWS::SQS::Queue`/`AWS::S3::Bucket`/`AWS::Glue::Database`/`AWS::Glue::Connection`/`AWS::DynamoDB::Table`
-  - `AWS::Glue::Database` ->` AWS::Glue::Connection`/`AWS::S3::Bucket`
+  - `AWS::Glue::Database` -> `AWS::Glue::Connection`/`AWS::S3::Bucket`
   - `AWS::Glue::Job` -> `AWS::IAM::Role`/`AWS::S3::Bucket`/`AWS::Glue::Connection`
-  - `AWS::Glue::Table` ->` AWS::Kinesis::Stream`/`AWS::S3::Bucket`/`AWS::Glue::Connection`/`AWS::Glue::Database`
+  - `AWS::Glue::Table` -> `AWS::Kinesis::Stream`/`AWS::S3::Bucket`/`AWS::Glue::Connection`/`AWS::Glue::Database`
 - Configuration status section on Cost Page
 - Alert in AppInsights dashboard if Config aggregator is of incorrect type
 
 ### Changed
+
 - Updated Homepage with quicklinks to common user actions and configuration status alerts to surface errors in the solution's deployment and their remediation steps
 - Accounts in accounts page now display if AWS Config is enabled in imported regions
 - Warning displayed on Accounts page in `SELF_MANAGED` mode if regional CloudFormation template is not deployed in imported region
@@ -49,6 +65,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced whitespace on diagram page
 
 ### Fixed
+
 - Account name could not be updated through form on Accounts page
 
 ## [2.2.4] - 2025-04-07

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct). 
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact 
+
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
 opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/NOTICE
+++ b/NOTICE
@@ -13,7 +13,7 @@ THIRD PARTY COMPONENTS
 
 This software includes third party software subject to the following copyrights:
 
-amazonlinux/amazonlinux under under the CC-BY-4.0 license.
+amazonlinux/amazonlinux under the CC-BY-4.0 license.
 @aws-crypto/sha256-browser under the Apache-2.0 license.
 @smithy/is-array-buffer under the Apache-2.0 license.
 tslib under the 0BSD license.
@@ -545,7 +545,7 @@ range-parser under the MIT license.
 @react-native/babel-plugin-codegen under the MIT license.
 babel-plugin-syntax-hermes-parser under the MIT license.
 babel-plugin-transform-flow-enums under the MIT license.
-babel-plugin-transform-imports under ISC license.
+babel-plugin-transform-imports under the ISC license.
 react-refresh under the MIT license.
 metro under the MIT license.
 ci-info under the MIT license.
@@ -603,7 +603,7 @@ terser under the BSD-2-Clause license.
 @jridgewell/source-map under the MIT license.
 serialize-error under the MIT license.
 throat under the MIT license.
-readline under the BSD license(s).
+readline under the Apache-2.0 license.
 @react-native/gradle-plugin under the MIT license.
 @react-native/js-polyfills under the MIT license.
 @react-native/normalize-colors under the MIT license.
@@ -1381,7 +1381,7 @@ lodash.forown under the MIT license.
 lodash.isobject under the MIT license.
 object-hash under the MIT license.
 ramda under the MIT license.
-randomcolor under the CC0 license.
+randomcolor under the CC0-1.0 license.
 react-cytoscapejs under the MIT license.
 react-error-boundary under the MIT license.
 react-papaparse under the MIT license.
@@ -1465,12 +1465,12 @@ OPEN SOURCE LICENSES
 Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0
 BSD-2-Clause - https://opensource.org/licenses/BSD-2-Clause
 BSD-3-Clause - https://opensource.org/licenses/BSD-3-Clause
-ISC - https://www.isc.org/licenses/
-MIT - https://opensource.org/license/mit/
+ISC - https://www.isc.org/licenses
+MIT - https://opensource.org/license/mit
 BlueOak-1.0.0 - https://blueoakcouncil.org/license/1.0.0
 CC-BY-4.0 - https://creativecommons.org/licenses/by/4.0/legalcode
 CC0-1.0 - https://creativecommons.org/publicdomain/zero/1.0/legalcode
 MIT-0 - https://github.com/aws/mit-0
 Python-2.0 - https://opensource.org/licenses/Python-2.0
-Unlicense - https://unlicense.org/
+Unlicense - https://unlicense.org
 Zlib - http://www.zlib.net/zlib_license.html

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Workload Discovery on AWS (v2.3.0)
+# Workload Discovery on AWS (v2.3.1)
 
 Workload Discovery on AWS is a tool that quickly visualizes AWS Cloud workloads as architecture diagrams. 
 You can use the solution to build, customize, and share detailed workload visualizations based on live data from AWS. 

--- a/deployment/build-open-source-dist.sh
+++ b/deployment/build-open-source-dist.sh
@@ -44,6 +44,7 @@ gitzip -d $dist_dir/$1.zip \
       -x "buildspec.yml" \
       -x ".viperlight*" \
       -x "internal" \
+      -x "build-tools" \
       -x "sonar-project.properties" \
       -x "solution-manifest.yaml" \
       -x ".nightswatch" \

--- a/source/backend/discovery/Dockerfile
+++ b/source/backend/discovery/Dockerfile
@@ -9,7 +9,6 @@ RUN dnf install nodejs -y
 RUN groupadd -r discovery && useradd -r -g discovery discovery
 
 RUN mkdir /code
-
 WORKDIR /code
 
 COPY package.json package-lock.json ./
@@ -17,5 +16,9 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 
 COPY src/ src/
+
+RUN chown -R discovery:discovery /code
+
+USER discovery
 
 CMD ["node", "src/index.mjs"]

--- a/source/backend/discovery/package-lock.json
+++ b/source/backend/discovery/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-discovery",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-discovery",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-api-gateway": "3.621.0",

--- a/source/backend/discovery/package.json
+++ b/source/backend/discovery/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-discovery",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "This contains the code that forms the discovery process for AWS Perspective.",
   "main": "index.mjs",
   "type": "module",
@@ -61,6 +61,6 @@
     "vitest": "^3.0.9"
   },
   "volta": {
-    "node": "20.12.2"
+    "node": "22.17.1"
   }
 }

--- a/source/backend/discovery/src/lib/awsClient/bedrockAgent.mjs
+++ b/source/backend/discovery/src/lib/awsClient/bedrockAgent.mjs
@@ -28,16 +28,6 @@ export function createBedrockAgentClient(credentials, region) {
         },
     );
 
-    const bedrockListKnowledgeBasesThrottler = createThrottler(
-        'bedrockListKnowledgeBasesThrottler',
-        credentials,
-        region,
-        {
-            limit: 5,
-            interval: 1000,
-        },
-    );
-
     const bedrockListDataSourcesThrottler = createThrottler(
         'bedrockListDataSourcesThrottler',
         credentials,
@@ -102,26 +92,6 @@ export function createBedrockAgentClient(credentials, region) {
             }
 
             return agents;
-        },
-        async getAllKnowledgeBases() {
-            const listKnowledgeBasesPaginator = paginateListKnowledgeBases(bedrockAgentPaginatorConfig, {
-                maxResults: 250,
-            });
-
-            const knowledgeBases = [];
-
-            for await (const {knowledgeBaseSummaries} of throttledPaginator(
-                bedrockListKnowledgeBasesThrottler,
-                listKnowledgeBasesPaginator,
-            )) {
-                // Process knowledge bases serially to reduce chances of rate limiting
-                for (const {knowledgeBaseId} of knowledgeBaseSummaries) {
-                    const {knowledgeBase} = await bedrockAgentClient.getKnowledgeBase({knowledgeBaseId});
-                    knowledgeBases.push(knowledgeBase);
-                }
-            }
-
-            return knowledgeBases;
         },
         async getAllDataSources(knowledgeBaseId) {
             const listDataSourcesPaginator = paginateListDataSources(bedrockAgentPaginatorConfig, {

--- a/source/backend/discovery/src/lib/sdkResources/createAllBatchResources.mjs
+++ b/source/backend/discovery/src/lib/sdkResources/createAllBatchResources.mjs
@@ -30,7 +30,6 @@ import {
     AWS_GLUE_CONNECTION,
     AWS_GLUE_CRAWLER,
     AWS_GLUE_DATABASE,
-    AWS_BEDROCK_KNOWLEDGE_BASE,
 } from '../constants.mjs';
 import {
     createArn,
@@ -222,35 +221,6 @@ async function createApplications(awsClient, credentials, accountId, region) {
                 resourceName: application.name,
             },
             application
-        );
-    });
-}
-
-async function createKnowledgeBases(
-    awsClient,
-    credentials,
-    accountId,
-    region
-) {
-    const bedrockAgentClient = awsClient.createBedrockAgentClient(
-        credentials,
-        region
-    );
-
-    const knowledgeBases = await bedrockAgentClient.getAllKnowledgeBases();
-
-    return knowledgeBases.map(knowledgeBase => {
-        return createConfigObject(
-            {
-                arn: knowledgeBase.knowledgeBaseArn,
-                accountId,
-                awsRegion: region,
-                availabilityZone: NOT_APPLICABLE,
-                resourceType: AWS_BEDROCK_KNOWLEDGE_BASE,
-                resourceId: knowledgeBase.knowledgeBaseId,
-                resourceName: knowledgeBase.name,
-            },
-            knowledgeBase
         );
     });
 }
@@ -584,7 +554,6 @@ async function createAllBatchResources(credentialsTuples, awsClient) {
         [REGIONAL, createGlueConnections],
         [REGIONAL, createGlueCrawlers],
         [REGIONAL, createGlueDatabases],
-        [REGIONAL, createKnowledgeBases],
         [REGIONAL, createMediaConnectFlows],
         [REGIONAL, createTargetGroups],
         [REGIONAL, createOpenSearchDomains],

--- a/source/backend/discovery/src/schemas/resourceTypes/AWS::Bedrock::KnowledgeBase.json
+++ b/source/backend/discovery/src/schemas/resourceTypes/AWS::Bedrock::KnowledgeBase.json
@@ -5,33 +5,33 @@
     "descriptors": [
       {
         "relationshipName": "Is associated with Role",
-        "path": "roleArn",
+        "path": "RoleArn",
         "identifierType": "arn"
       },
       {
         "relationshipName": "Is associated with",
-        "path": "knowledgeBaseConfiguration.kendraIndexArn",
+        "path": "KnowledgeBaseConfiguration.KendraIndexArn",
         "identifierType": "arn"
       },
       {
         "relationshipName": "Is associated with",
-        "path": "storageConfiguration.rdsConfiguration.resourceArn",
+        "path": "StorageConfiguration.RdsConfiguration.ResourceArn",
         "identifierType": "arn"
       },
       {
         "relationshipName": "Is associated with",
-        "path": "storageConfiguration.opensearchServerlessConfiguration.collectionArn",
+        "path": "StorageConfiguration.OpensearchServerlessConfiguration.CollectionArn",
         "identifierType": "arn"
       },
       {
         "relationshipName": "Is associated with",
-        "path": "vectorKnowledgeBaseConfiguration.supplementalDataStorageConfiguration.storageLocations[*].s3Location",
+        "path": "VectorKnowledgeBaseConfiguration.SupplementalDataStorageConfiguration.StorageLocations[*].S3Location",
         "identifierType": "s3Uri"
       },
       {
         "relationshipName": "Is associated with",
         "resourceType": "AWS::Redshift::Cluster",
-        "path": "sqlKnowledgeBaseConfiguration.redshiftConfiguration.queryEngineConfiguration.clusterIdentifier",
+        "path": "SqlKnowledgeBaseConfiguration.RedshiftConfiguration.QueryEngineConfiguration.ClusterIdentifier",
         "identifierType": "resourceId"
       }
     ]

--- a/source/backend/discovery/test/additionalRelationships/bedrock/knowledgeBase.test.mjs
+++ b/source/backend/discovery/test/additionalRelationships/bedrock/knowledgeBase.test.mjs
@@ -41,10 +41,10 @@ function generateBedrockKnowledgeBase(options = {}) {
 describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
 
     it('should add relationship for IAM role', async () => {
-        const roleArn = `arn:aws:iam::${ACCOUNT_X}:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase`;
+        const RoleArn = `arn:aws:iam::${ACCOUNT_X}:role/service-role/AmazonBedrockExecutionRoleForKnowledgeBase`;
         const mockKnowledgeBase = generateBedrockKnowledgeBase({
             configuration: {
-                roleArn,
+                RoleArn,
             },
         });
 
@@ -58,21 +58,21 @@ describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
         );
 
         const roleRelationship = relationships.find(
-            r => r.arn === roleArn,
+            r => r.arn === RoleArn,
         );
 
         assert.deepEqual(roleRelationship, {
             relationshipName: IS_ASSOCIATED_WITH + 'Role',
-            arn: roleArn
+            arn: RoleArn
         });
     });
 
     it('should add relationship for Kendra index', async () => {
-        const kendraIndexArn = `arn:aws:kendra:us-east-1:${ACCOUNT_X}:index/idx-12345abcdef`;
+        const KendraIndexArn = `arn:aws:kendra:us-east-1:${ACCOUNT_X}:index/idx-12345abcdef`;
         const mockKnowledgeBase = generateBedrockKnowledgeBase({
             configuration: {
-                knowledgeBaseConfiguration: {
-                    kendraIndexArn,
+                KnowledgeBaseConfiguration: {
+                    KendraIndexArn,
                 }
             },
         });
@@ -87,22 +87,22 @@ describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
         );
 
         const kendraIndexRelationship = relationships.find(
-            r => r.arn === kendraIndexArn,
+            r => r.arn === KendraIndexArn,
         );
 
         assert.deepEqual(kendraIndexRelationship, {
             relationshipName: IS_ASSOCIATED_WITH,
-            arn: kendraIndexArn
+            arn: KendraIndexArn
         });
     });
 
     it('should add relationship for RDS clusters', async () => {
-        const rdsClusterArn = `arn:aws:rds:us-east-1:${ACCOUNT_X}:cluster:aurora-cluster-1`;
+        const ResourceArn = `arn:aws:rds:us-east-1:${ACCOUNT_X}:cluster:aurora-cluster-1`;
         const mockKnowledgeBase = generateBedrockKnowledgeBase({
             configuration: {
-                storageConfiguration: {
-                    rdsConfiguration: {
-                        resourceArn: rdsClusterArn,
+                StorageConfiguration: {
+                    RdsConfiguration: {
+                        ResourceArn,
                     }
                 }
             },
@@ -118,22 +118,22 @@ describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
         );
 
         const rdsClusterRelationship = relationships.find(
-            r => r.arn === rdsClusterArn,
+            r => r.arn === ResourceArn,
         );
 
         assert.deepEqual(rdsClusterRelationship, {
             relationshipName: IS_ASSOCIATED_WITH,
-            arn: rdsClusterArn
+            arn: ResourceArn
         });
     });
 
     it('should add relationship for OpenSearch Serverless collections', async () => {
-        const collectionArn = `arn:aws:aoss:us-east-1:${ACCOUNT_X}:collection/my-collection`;
+        const CollectionArn = `arn:aws:aoss:us-east-1:${ACCOUNT_X}:collection/my-collection`;
         const mockKnowledgeBase = generateBedrockKnowledgeBase({
             configuration: {
-                storageConfiguration: {
-                    opensearchServerlessConfiguration: {
-                        collectionArn,
+                StorageConfiguration: {
+                    OpensearchServerlessConfiguration: {
+                        CollectionArn,
                     }
                 }
             },
@@ -149,23 +149,23 @@ describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
         );
 
         const collectionRelationship = relationships.find(
-            r => r.arn === collectionArn,
+            r => r.arn === CollectionArn,
         );
 
         assert.deepEqual(collectionRelationship, {
             relationshipName: IS_ASSOCIATED_WITH,
-            arn: collectionArn
+            arn: CollectionArn
         });
     });
 
     it('should add relationships for Redshift clusters', async () => {
-        const clusterIdentifier = 'redshift-cluster-1';
+        const ClusterIdentifier = 'redshift-cluster-1';
         const mockKnowledgeBase = generateBedrockKnowledgeBase({
             configuration: {
-                sqlKnowledgeBaseConfiguration: {
-                    redshiftConfiguration: {
-                        queryEngineConfiguration: {
-                            clusterIdentifier,
+                SqlKnowledgeBaseConfiguration: {
+                    RedshiftConfiguration: {
+                        QueryEngineConfiguration: {
+                            ClusterIdentifier,
                         }
                     }
                 }
@@ -182,13 +182,13 @@ describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
         );
 
         const redshiftRelationship = relationships.find(
-            r => r.resourceId === clusterIdentifier,
+            r => r.resourceId === ClusterIdentifier,
         );
 
         assert.deepEqual(redshiftRelationship, {
             relationshipName: IS_ASSOCIATED_WITH,
             resourceType: AWS_REDSHIFT_CLUSTER,
-            resourceId: clusterIdentifier
+            resourceId: ClusterIdentifier
         });
     });
 
@@ -200,14 +200,14 @@ describe(`addAdditionalRelationships - ${AWS_BEDROCK_KNOWLEDGE_BASE}`, () => {
 
         const mockKnowledgeBase = generateBedrockKnowledgeBase({
             configuration: {
-                vectorKnowledgeBaseConfiguration: {
-                    supplementalDataStorageConfiguration: {
-                        storageLocations: [
+                VectorKnowledgeBaseConfiguration: {
+                    SupplementalDataStorageConfiguration: {
+                        StorageLocations: [
                             {
-                                s3Location: `s3://${bucketName1}/path/to/data`
+                                S3Location: `s3://${bucketName1}/path/to/data`
                             },
                             {
-                                s3Location: `s3://${bucketName2}/other/path`
+                                S3Location: `s3://${bucketName2}/other/path`
                             }
                         ]
                     }

--- a/source/backend/discovery/test/awsClient/bedrock-agent.test.js
+++ b/source/backend/discovery/test/awsClient/bedrock-agent.test.js
@@ -28,7 +28,6 @@ describe('BedrockAgent Client', () => {
     const {
         getAllAgents,
         getAllDataSources,
-        getAllKnowledgeBases,
         getAllAgentVersions,
         getAllAgentKnowledgeBases,
     } = createBedrockAgentClient(mockCredentials, 'us-east-1');
@@ -144,117 +143,6 @@ describe('BedrockAgent Client', () => {
             ]);
         });
 
-    });
-
-    describe('getAllKnowledgeBases', () => {
-        it('should get all knowledge bases with pagination', async () => {
-            const mockBedrockAgentClient = mockClient(BedrockAgentClient);
-
-            const knowledgeBaseSummariesPages = {
-                page1: {
-                    knowledgeBaseSummaries: [
-                        {knowledgeBaseId: 'kb1', name: 'Knowledge Base 1', status: 'READY'},
-                        {knowledgeBaseId: 'kb2', name: 'Knowledge Base 2', status: 'READY'},
-                    ],
-                    nextToken: 'token1',
-                },
-                token1: {
-                    knowledgeBaseSummaries: [
-                        {knowledgeBaseId: 'kb3', name: 'Knowledge Base 3', status: 'READY'},
-                        {knowledgeBaseId: 'kb4', name: 'Knowledge Base 4', status: 'READY'},
-                    ],
-                    nextToken: 'token2',
-                },
-                token2: {
-                    knowledgeBaseSummaries: [
-                        {knowledgeBaseId: 'kb5', name: 'Knowledge Base 5', status: 'READY'},
-                    ],
-                },
-            };
-
-            const knowledgeBaseDetails = {
-                kb1: {
-                    knowledgeBase: {
-                        knowledgeBaseId: 'kb1',
-                        name: 'Knowledge Base 1',
-                        description: 'Description for Knowledge Base 1',
-                    },
-                },
-                kb2: {
-                    knowledgeBase: {
-                        knowledgeBaseId: 'kb2',
-                        name: 'Knowledge Base 2',
-                        description: 'Description for Knowledge Base 2',
-                    },
-                },
-                kb3: {
-                    knowledgeBase: {
-                        knowledgeBaseId: 'kb3',
-                        name: 'Knowledge Base 3',
-                        description: 'Description for Knowledge Base 3',
-                    },
-                },
-                kb4: {
-                    knowledgeBase: {
-                        knowledgeBaseId: 'kb4',
-                        name: 'Knowledge Base 4',
-                        description: 'Description for Knowledge Base 4',
-                    },
-                },
-                kb5: {
-                    knowledgeBase: {
-                        knowledgeBaseId: 'kb5',
-                        name: 'Knowledge Base 5',
-                        description: 'Description for Knowledge Base 5',
-                    },
-                },
-            };
-
-            mockBedrockAgentClient.on(ListKnowledgeBasesCommand)
-                .callsFake(input => {
-                    const {nextToken} = input;
-                    if (nextToken) {
-                        return knowledgeBaseSummariesPages[nextToken];
-                    }
-                    return knowledgeBaseSummariesPages['page1'];
-                });
-
-            mockBedrockAgentClient.on(GetKnowledgeBaseCommand)
-                .callsFake(input => {
-                    const {knowledgeBaseId} = input;
-                    return knowledgeBaseDetails[knowledgeBaseId];
-                });
-
-            const knowledgeBases = await getAllKnowledgeBases();
-
-            assert.deepEqual(knowledgeBases, [
-                {
-                    knowledgeBaseId: 'kb1',
-                    name: 'Knowledge Base 1',
-                    description: 'Description for Knowledge Base 1',
-                },
-                {
-                    knowledgeBaseId: 'kb2',
-                    name: 'Knowledge Base 2',
-                    description: 'Description for Knowledge Base 2',
-                },
-                {
-                    knowledgeBaseId: 'kb3',
-                    name: 'Knowledge Base 3',
-                    description: 'Description for Knowledge Base 3',
-                },
-                {
-                    knowledgeBaseId: 'kb4',
-                    name: 'Knowledge Base 4',
-                    description: 'Description for Knowledge Base 4',
-                },
-                {
-                    knowledgeBaseId: 'kb5',
-                    name: 'Knowledge Base 5',
-                    description: 'Description for Knowledge Base 5',
-                },
-            ]);
-        });
     });
 
     describe('getAllDataSources', () => {

--- a/source/backend/discovery/test/getAllSdkResources/bedrock-agent.test.mjs
+++ b/source/backend/discovery/test/getAllSdkResources/bedrock-agent.test.mjs
@@ -41,10 +41,10 @@ function generateBedrockAgent(region, accountId) {
 function generateBedrockKnowledgeBase(region, accountId) {
     const id = `kb-${generateRandomInt(0, 10000)}`;
     return {
-        knowledgeBaseId: id,
-        name: `KnowledgeBase-${id}`,
-        knowledgeBaseArn: `arn:aws:bedrock:${region}:${accountId}:knowledge-base/${id}`,
-        description: `Description for knowledge base ${id}`,
+        KnowledgeBaseId: id,
+        Name: `KnowledgeBase-${id}`,
+        KnowledgeBaseArn: `arn:aws:bedrock:${region}:${accountId}:knowledge-base/${id}`,
+        Description: `Description for knowledge base ${id}`,
     };
 }
 
@@ -169,80 +169,6 @@ describe('getAllSdkResources - Bedrock Agent', () => {
             });
         });
 
-    });
-
-    describe(AWS_BEDROCK_KNOWLEDGE_BASE, () => {
-
-        it('should discover Bedrock knowledge bases', async () => {
-            const kbEuWest2 = generateBedrockKnowledgeBase(REGION_EU_WEST_2, ACCOUNT_X);
-            const kbUsWest2 = generateBedrockKnowledgeBase(REGION_US_WEST_2, ACCOUNT_Z);
-
-            const mockBedrockAgentClient = {
-                createBedrockAgentClient(credentials, region) {
-                    return {
-                        getAllKnowledgeBases() {
-                            if (R.equals(credentials, credentialsX) && region === REGION_EU_WEST_2) {
-                                return [kbEuWest2];
-                            } else if (R.equals(credentials, credentialsZ) && region === REGION_US_WEST_2) {
-                                return [kbUsWest2];
-                            } else {
-                                return [];
-                            }
-                        },
-                        getAllDataSources() {
-                            return [];
-                        },
-                        getAllAgents() {
-                            return [];
-                        },
-                        getAllAgentVersions() {
-                            return [];
-                        },
-                    };
-                },
-            };
-
-            const actual = await getAllSdkResources(
-                {...mockAwsClient, ...mockBedrockAgentClient},
-                [],
-            );
-
-            const kbEuWest2Arn = kbEuWest2.knowledgeBaseArn;
-            const kbUsWest2Arn = kbUsWest2.knowledgeBaseArn;
-
-            const actualKbEuWest2 = actual.find(x => x.arn === kbEuWest2Arn);
-            const actualKbUsWest2 = actual.find(x => x.arn === kbUsWest2Arn);
-
-            assert.deepEqual(actualKbEuWest2, {
-                id: kbEuWest2Arn,
-                accountId: ACCOUNT_X,
-                arn: kbEuWest2Arn,
-                availabilityZone: NOT_APPLICABLE,
-                awsRegion: REGION_EU_WEST_2,
-                configuration: kbEuWest2,
-                configurationItemStatus: RESOURCE_DISCOVERED,
-                resourceId: kbEuWest2.knowledgeBaseId,
-                resourceName: kbEuWest2.name,
-                resourceType: AWS_BEDROCK_KNOWLEDGE_BASE,
-                tags: [],
-                relationships: [],
-            });
-
-            assert.deepEqual(actualKbUsWest2, {
-                id: kbUsWest2Arn,
-                accountId: ACCOUNT_Z,
-                arn: kbUsWest2Arn,
-                availabilityZone: NOT_APPLICABLE,
-                awsRegion: REGION_US_WEST_2,
-                configuration: kbUsWest2,
-                configurationItemStatus: RESOURCE_DISCOVERED,
-                resourceId: kbUsWest2.knowledgeBaseId,
-                resourceName: kbUsWest2.name,
-                resourceType: AWS_BEDROCK_KNOWLEDGE_BASE,
-                tags: [],
-                relationships: [],
-            });
-        });
     });
 
     describe(AWS_BEDROCK_DATA_SOURCE, () => {

--- a/source/backend/functions/account-import-templates-api/package-lock.json
+++ b/source/backend/functions/account-import-templates-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-import-templates",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-import-templates",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.10.0"

--- a/source/backend/functions/account-import-templates-api/package.json
+++ b/source/backend/functions/account-import-templates-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-import-templates",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "Lambda function that serves cfn templates for account and region importing",
   "main": "index.mjs",
   "type": "module",

--- a/source/backend/functions/application-monitoring/package-lock.json
+++ b/source/backend/functions/application-monitoring/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-search-api",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-search-api",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.10.0",

--- a/source/backend/functions/application-monitoring/package.json
+++ b/source/backend/functions/application-monitoring/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-search-api",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "The lambda function that queries health status of WD solution",
   "main": "src/index.mjs",
   "type": "module",

--- a/source/backend/functions/cost-parser/package-lock.json
+++ b/source/backend/functions/cost-parser/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-cost",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-cost",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.10.0",

--- a/source/backend/functions/cost-parser/package.json
+++ b/source/backend/functions/cost-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-cost",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/source/backend/functions/cur-notification/package-lock.json
+++ b/source/backend/functions/cur-notification/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-cur-notification",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-cur-notification",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.645.0"

--- a/source/backend/functions/cur-notification/package.json
+++ b/source/backend/functions/cur-notification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-cur-notification",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/source/backend/functions/cur-setup/package-lock.json
+++ b/source/backend/functions/cur-setup/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-cur-setup",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-cur-setup",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-glue": "^3.645.0",

--- a/source/backend/functions/cur-setup/package.json
+++ b/source/backend/functions/cur-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-cur-setup",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/source/backend/functions/graph-api/package-lock.json
+++ b/source/backend/functions/graph-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-graph-api",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-graph-api",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.10.0",

--- a/source/backend/functions/graph-api/package.json
+++ b/source/backend/functions/graph-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-graph-api",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "The lambda function that queries the Neptune database",
   "main": "src/index.mjs",
   "type": "module",

--- a/source/backend/functions/metrics-subscription-filter/package-lock.json
+++ b/source/backend/functions/metrics-subscription-filter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics-subscription-filter",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics-subscription-filter",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.1.1",

--- a/source/backend/functions/metrics-subscription-filter/package.json
+++ b/source/backend/functions/metrics-subscription-filter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-subscription-filter",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "Lambda function used to handle operational metrics subscription filter",
   "main": "index.mjs",
   "scripts": {

--- a/source/backend/functions/metrics/package-lock.json
+++ b/source/backend/functions/metrics/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metrics",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "metrics",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.2.0",

--- a/source/backend/functions/metrics/package.json
+++ b/source/backend/functions/metrics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "",
   "main": "index.js",
   "type": "module",

--- a/source/backend/functions/myapplications/package-lock.json
+++ b/source/backend/functions/myapplications/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-export-myapplications",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-export-myapplications",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.1.1",

--- a/source/backend/functions/myapplications/package.json
+++ b/source/backend/functions/myapplications/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-export-myapplications",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "Lambda function that exports to myApplications",
   "main": "index.mjs",
   "type": "module",

--- a/source/backend/functions/opensearch-setup/package-lock.json
+++ b/source/backend/functions/opensearch-setup/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "opensearch-setup",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "opensearch-setup",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-node": "^3.645.0",

--- a/source/backend/functions/opensearch-setup/package.json
+++ b/source/backend/functions/opensearch-setup/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opensearch-setup",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "Custom resource that creates index in OpenSearch.",
   "main": "src/index.js",
   "scripts": {

--- a/source/backend/functions/search-api/package-lock.json
+++ b/source/backend/functions/search-api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-search-api",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-search-api",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.10.0",

--- a/source/backend/functions/search-api/package.json
+++ b/source/backend/functions/search-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-search-api",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "The lambda function that queries the OpenSearch database",
   "main": "src/index.mjs",
   "type": "module",

--- a/source/backend/functions/settings/package-lock.json
+++ b/source/backend/functions/settings/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wd-settings",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wd-settings",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-lambda-powertools/logger": "2.10.0",

--- a/source/backend/functions/settings/package.json
+++ b/source/backend/functions/settings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wd-settings",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "Lambda function that stores WD configuration data in DynamoDB",
   "main": "index.js",
   "type": "module",

--- a/source/backend/functions/settings/src/schemas.mjs
+++ b/source/backend/functions/settings/src/schemas.mjs
@@ -58,7 +58,7 @@ const AccountIdSchema = z.union([
 
 const RegionSchema = z.object({
     name: regionEnum,
-    isConfigEnabled: z.boolean().optional(),
+    isConfigEnabled: z.boolean().nullish(),
     lastCrawled: z.string().datetime().optional(),
 });
 

--- a/source/cfn/templates/application-insights.template
+++ b/source/cfn/templates/application-insights.template
@@ -160,7 +160,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub ${AWS::StackName}-AppSyncSearchRole
+        - PolicyName: WdAppSyncAppMonitoringPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/source/cfn/templates/appsync-api.template
+++ b/source/cfn/templates/appsync-api.template
@@ -38,7 +38,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub ${AWS::StackName}-AWSAppSyncPushToCloudWatchLogsPolicy
+        - PolicyName: WdAppSyncCloudWatchLogsPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -55,7 +55,9 @@ Resources:
   PerspectiveAppSyncApi:
     Type: AWS::AppSync::GraphQLApi
     Properties:
-      Name: !Sub ${AWS::StackName}-AppSync-api
+      Name: !Sub
+        - WdAppSyncApi-${uuid}
+        - uuid: !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ]
       AuthenticationType: AMAZON_COGNITO_USER_POOLS
       AdditionalAuthenticationProviders:
         - AuthenticationType: AWS_IAM

--- a/source/cfn/templates/main.template
+++ b/source/cfn/templates/main.template
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 
-Description: Workload Discovery on AWS Main Template (SO0075a) - Solution - Main Template (uksb-1r0720e27) (version:<VERSION>)
+Description: (SO0075) Workload Discovery on AWS Main Template - Solution - Main Template (uksb-1r0720e27) (version:<VERSION>)
 
 Transform: AWS::Serverless-2016-10-31
 

--- a/source/cfn/templates/neptune.template
+++ b/source/cfn/templates/neptune.template
@@ -253,7 +253,7 @@ Resources:
   WDNeptuneDBCluster:
     Type: AWS::Neptune::DBCluster
     Properties:
-      EngineVersion: 1.4.5.0
+      EngineVersion: 1.4.5.1
       ServerlessScalingConfiguration:
         MinCapacity: !Ref MinNCUs
         MaxCapacity: !Ref MaxNCUs

--- a/source/cfn/templates/settings-resolvers.template
+++ b/source/cfn/templates/settings-resolvers.template
@@ -68,7 +68,7 @@ Resources:
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess
       Policies:
-        - PolicyName: !Sub ${AWS::StackName}-SettingsAppSyncLambdaPolicy
+        - PolicyName: WdSettingsAppSyncLambdaPolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:
@@ -135,7 +135,7 @@ Resources:
             Action:
               - sts:AssumeRole
       Policies:
-        - PolicyName: !Sub ${AWS::StackName}-AppSyncRole
+        - PolicyName: WdSettingsAppSyncInvokePolicy
           PolicyDocument:
             Version: 2012-10-17
             Statement:

--- a/source/cfn/templates/webui.template
+++ b/source/cfn/templates/webui.template
@@ -102,7 +102,9 @@ Resources:
     Type: AWS::CloudFront::ResponseHeadersPolicy
     Properties:
       ResponseHeadersPolicyConfig:
-        Name: !Sub '${AWS::StackName}-SecurityHeaders'
+        Name: !Sub
+          - WdSecurityHeaders-${uuid}
+          - uuid: !Select [ 2, !Split [ '/', !Ref 'AWS::StackId' ] ]
         SecurityHeadersConfig:
           ContentSecurityPolicy:
             ContentSecurityPolicy: |-

--- a/source/frontend/package-lock.json
+++ b/source/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-discovery-ui",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-discovery-ui",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-amplify/ui-react": "5.3.2",

--- a/source/frontend/package.json
+++ b/source/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-discovery-ui",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "private": true,
   "description": "UI code for the Workload Discovery solution",
   "author": {

--- a/source/frontend/src/components/Costs/QueryBuilder/CostStatus.js
+++ b/source/frontend/src/components/Costs/QueryBuilder/CostStatus.js
@@ -79,12 +79,12 @@ export const CostStatus = () => {
                 const isStale =
                     dayjs().diff(dayjs(lastProcessed), 'hour') > DAY_IN_HOURS;
 
+                const staleMsg = isStale ? 'warning' : 'success';
+
                 const type =
                     costStatus.crawler.errorMessage != null
                         ? 'error'
-                        : isStale
-                          ? 'warning'
-                          : 'success';
+                        : staleMsg;
 
                 setLastProcessedStatus({
                     type,

--- a/source/frontend/src/components/Diagrams/Draw/DrawDiagram/DiagramControlsPanel.js
+++ b/source/frontend/src/components/Diagrams/Draw/DrawDiagram/DiagramControlsPanel.js
@@ -278,10 +278,9 @@ const DiagramControlPanel = ({settings}) => {
             <SpaceBetween size="s" direction="horizontal">
                 {statusMessage != null && (
                     <Box margin={{vertical: 'xxs'}} display={'block'}>
-                        <StatusIndicator type={statusMessage.type}>
+                        <StatusIndicator type={statusMessage?.type}>
                             {' '}
-                            {/* NOSONAR - null check is done by R.isNil */}
-                            {statusMessage.message}
+                            {statusMessage?.message}
                         </StatusIndicator>
                     </Box>
                 )}

--- a/source/frontend/src/cytoscape/plugins/svg/svgCanvas.js
+++ b/source/frontend/src/cytoscape/plugins/svg/svgCanvas.js
@@ -11,8 +11,111 @@ export class Context extends ParentContextClass {
         this.embedImages = options?.embedImages ?? false;
     }
 
+    // Helper method to process drawImage arguments
+    _processDrawImageArgs(args) {
+        const image = args[0];
+        let dx,
+            dy,
+            dw,
+            dh,
+            sx = 0,
+            sy = 0,
+            sw,
+            sh;
+
+        if (args.length === 3) {
+            [, dx, dy] = args;
+            sw = image.width;
+            sh = image.height;
+            dw = sw;
+            dh = sh;
+        } else if (args.length === 5) {
+            [, dx, dy, dw, dh] = args;
+            sw = image.width;
+            sh = image.height;
+        } else if (args.length === 9) {
+            [, sx, sy, sw, sh, dx, dy, dw, dh] = args;
+        }
+        return {image, dx, dy, dw, dh, sx, sy, sw, sh};
+    }
+
+    // Handle Context type images
+    _handleContextImage(image, matrix, parent) {
+        const svg = image.getSvg().cloneNode(true);
+        if (svg.childNodes && svg.childNodes.length > 1) {
+            const defs = svg.childNodes[0];
+            while (defs.childNodes.length) {
+                const id = defs.childNodes[0].getAttribute('id');
+                this.__ids[id] = id;
+                this.__defs.appendChild(defs.childNodes[0]);
+            }
+            const group = svg.childNodes[1];
+            if (group) {
+                this.__applyTransformation(group, matrix);
+                parent.appendChild(group);
+            }
+        }
+    }
+
+    // Handle DOM images (Canvas or IMG)
+    _handleDOMImage(params) {
+        const {image, dw, dh, sx, sy, sw, sh, matrix, parent} = params;
+        const svgImage = this.__createElement('image');
+        svgImage.setAttribute('width', dw);
+        svgImage.setAttribute('height', dh);
+        svgImage.setAttribute('preserveAspectRatio', 'none');
+
+        let processedImage = image;
+        if (
+            this.embedImages ||
+            sx ||
+            sy ||
+            sw !== image.width ||
+            sh !== image.height
+        ) {
+            // Crop the image using a temporary canvas
+            const canvas = this.__document.createElement('canvas');
+            canvas.width = dw;
+            canvas.height = dh;
+            const context = canvas.getContext('2d');
+            context.drawImage(image, sx, sy, sw, sh, 0, 0, dw, dh);
+            processedImage = canvas;
+        }
+        this.__applyTransformation(svgImage, matrix);
+        svgImage.setAttributeNS(
+            'http://www.w3.org/1999/xlink',
+            'xlink:href',
+            processedImage.nodeName === 'CANVAS'
+                ? processedImage.toDataURL()
+                : processedImage.getAttribute('src')
+        );
+        parent.appendChild(svgImage);
+    }
+
+    // Main handler for image content
+    _handleDrawImageContent(params) {
+        const {image, dx, dy, dw, dh, sx, sy, sw, sh, parent} = params;
+        const matrix = this.getTransform().translate(dx, dy);
+
+        if (image instanceof Context) {
+            this._handleContextImage(image, matrix, parent);
+        } else if (image.nodeName === 'CANVAS' || image.nodeName === 'IMG') {
+            this._handleDOMImage({
+                image,
+                dw,
+                dh,
+                sx,
+                sy,
+                sw,
+                sh,
+                matrix,
+                parent,
+            });
+        }
+    }
+
     drawImage() {
-        //convert arguments to a real array
+        // Convert arguments to a real array
         let args = Array.prototype.slice.call(arguments),
             image = args[0],
             dx,
@@ -23,38 +126,18 @@ export class Context extends ParentContextClass {
             sy = 0,
             sw,
             sh,
-            parent,
-            svg,
-            defs,
-            group,
-            svgImage,
-            canvas,
-            context,
-            id;
+            parent;
 
-        if (args.length === 3) {
-            dx = args[1];
-            dy = args[2];
-            sw = image.width;
-            sh = image.height;
-            dw = sw;
-            dh = sh;
-        } else if (args.length === 5) {
-            dx = args[1];
-            dy = args[2];
-            dw = args[3];
-            dh = args[4];
-            sw = image.width;
-            sh = image.height;
-        } else if (args.length === 9) {
-            sx = args[1];
-            sy = args[2];
-            sw = args[3];
-            sh = args[4];
-            dx = args[5];
-            dy = args[6];
-            dw = args[7];
-            dh = args[8];
+        if ([3, 5, 9].includes(args.length)) {
+            const processedArgs = this._processDrawImageArgs(args);
+            dx = processedArgs.dx;
+            dy = processedArgs.dy;
+            dw = processedArgs.dw;
+            dh = processedArgs.dh;
+            sx = processedArgs.sx;
+            sy = processedArgs.sy;
+            sw = processedArgs.sw;
+            sh = processedArgs.sh;
         } else {
             throw new Error(
                 'Invalid number of arguments passed to drawImage: ' +
@@ -63,53 +146,17 @@ export class Context extends ParentContextClass {
         }
 
         parent = this.__closestGroupOrSvg();
-        const matrix = this.getTransform().translate(dx, dy);
-        if (image instanceof Context) {
-            svg = image.getSvg().cloneNode(true);
-            if (svg.childNodes && svg.childNodes.length > 1) {
-                defs = svg.childNodes[0];
-                while (defs.childNodes.length) {
-                    id = defs.childNodes[0].getAttribute('id');
-                    this.__ids[id] = id;
-                    this.__defs.appendChild(defs.childNodes[0]);
-                }
-                group = svg.childNodes[1];
-                if (group) {
-                    this.__applyTransformation(group, matrix);
-                    parent.appendChild(group);
-                }
-            }
-        } else if (image.nodeName === 'CANVAS' || image.nodeName === 'IMG') {
-            //canvas or image
-            svgImage = this.__createElement('image');
-            svgImage.setAttribute('width', dw);
-            svgImage.setAttribute('height', dh);
-            svgImage.setAttribute('preserveAspectRatio', 'none');
-
-            if (
-                this.embedImages ||
-                sx ||
-                sy ||
-                sw !== image.width ||
-                sh !== image.height
-            ) {
-                //crop the image using a temporary canvas
-                canvas = this.__document.createElement('canvas');
-                canvas.width = dw;
-                canvas.height = dh;
-                context = canvas.getContext('2d');
-                context.drawImage(image, sx, sy, sw, sh, 0, 0, dw, dh);
-                image = canvas;
-            }
-            this.__applyTransformation(svgImage, matrix);
-            svgImage.setAttributeNS(
-                'http://www.w3.org/1999/xlink',
-                'xlink:href',
-                image.nodeName === 'CANVAS'
-                    ? image.toDataURL()
-                    : image.getAttribute('src')
-            );
-            parent.appendChild(svgImage);
-        }
+        this._handleDrawImageContent({
+            image,
+            dx,
+            dy,
+            dw,
+            dh,
+            sx,
+            sy,
+            sw,
+            sh,
+            parent,
+        });
     }
 }

--- a/source/sdk/js/package-lock.json
+++ b/source/sdk/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "workload-discovery-sdk",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "workload-discovery-sdk",
-      "version": "v2.3.0",
+      "version": "v2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-providers": "3.621.0",

--- a/source/sdk/js/package.json
+++ b/source/sdk/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workload-discovery-sdk",
-  "version": "v2.3.0",
+  "version": "v2.3.1",
   "description": "SDK for Workload Discovery on AWS",
   "module": "dist/index.mjs",
   "exports": {


### PR DESCRIPTION
### Added

- `AWS::EC2::Volume` -> `AWS::EC2::VPC`/`AWS::EC2::Subnet` relationships

### Fixed

- Workload Discovery ECS tasks failing with AWS Config errors [593](https://github.com/aws-solutions/workload-discovery-on-aws/issues/593)

### Changed

- `AWS::Bedrock::KnowledgeBase` resource type is now discovered via AWS Config
- Update Neptune Engine version to `1.4.5.1`.
